### PR TITLE
Feature/document size check

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -46,4 +46,3 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       configuration: '%$SilverStripe\SearchService\Service\IndexConfiguration'
       registry: '%$SilverStripe\SearchService\Service\DocumentFetchCreatorRegistry'
-      service: '%$SilverStripe\SearchService\Interfaces\IndexingInterface'

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -46,3 +46,4 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       configuration: '%$SilverStripe\SearchService\Service\IndexConfiguration'
       registry: '%$SilverStripe\SearchService\Service\DocumentFetchCreatorRegistry'
+      service: '%$SilverStripe\SearchService\Interfaces\IndexingInterface'

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -176,6 +176,14 @@ Let's look at all the settings on the `IndexConfiguration` class:
             More information in the <a href="usage.md">usage</a> section</td>
             <td>"source_class"</td>
         </tr>
+        <tr>
+            <td>document_max_size</td>
+            <td>int|null</td>
+            <td>An int specifying the max size a document can be in bytes. If set any document
+            that is larger than the defined size will not be indexed and a warning will be thrown
+            with the details of the document</td>
+            <td>null</td>
+        </tr>
     </tbody>
 </table>
 

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -177,7 +177,7 @@ Let's look at all the settings on the `IndexConfiguration` class:
             <td>"source_class"</td>
         </tr>
         <tr>
-            <td>document_max_size</td>
+            <td>max_document_size</td>
             <td>int|null</td>
             <td>An int specifying the max size a document can be in bytes. If set any document
             that is larger than the defined size will not be indexed and a warning will be thrown

--- a/src/Interfaces/IndexingInterface.php
+++ b/src/Interfaces/IndexingInterface.php
@@ -7,7 +7,6 @@ use SilverStripe\SearchService\Exception\IndexingServiceException;
 
 interface IndexingInterface extends BatchDocumentInterface
 {
-
     /**
      * @param DocumentInterface $item
      * @return $this
@@ -63,4 +62,9 @@ interface IndexingInterface extends BatchDocumentInterface
      * @throws IndexConfigurationException
      */
     public function validateField(string $field): void;
+
+    /**
+     * @return int
+     */
+    public function getMaxDocumentSize(): int;
 }

--- a/src/Interfaces/IndexingInterface.php
+++ b/src/Interfaces/IndexingInterface.php
@@ -22,6 +22,12 @@ interface IndexingInterface extends BatchDocumentInterface
     public function removeDocument(DocumentInterface $doc): IndexingInterface;
 
     /**
+     * @return int
+     * @throws IndexingServiceException
+     */
+    public function getMaxDocumentSize(): int;
+
+    /**
      * @param string $id
      * @return DocumentInterface
      * @throws IndexingServiceException
@@ -62,9 +68,4 @@ interface IndexingInterface extends BatchDocumentInterface
      * @throws IndexConfigurationException
      */
     public function validateField(string $field): void;
-
-    /**
-     * @return int
-     */
-    public function getMaxDocumentSize(): int;
 }

--- a/src/Service/AppSearch/AppSearchService.php
+++ b/src/Service/AppSearch/AppSearchService.php
@@ -82,6 +82,19 @@ class AppSearchService implements IndexingInterface
             }
 
             $fields = $this->getBuilder()->toArray($item);
+
+            $documentMaxSize = $this->getConfiguration()->getDocumentMaxSize();
+            if ($documentMaxSize  && strlen(serialize($fields)) >= $documentMaxSize) {
+                trigger_error(sprintf(
+                    'Document title: %s, Document class: %s, Document ID %s: exceeds maximum allowed document size of %s bytes',
+                    $fields['title'],
+                    $fields['source_class'],
+                    $fields['record_id'],
+                    $documentMaxSize
+                ), E_USER_WARNING);
+                continue;
+            }
+
             $indexes = $this->getConfiguration()->getIndexesForDocument($item);
             foreach (array_keys($indexes) as $indexName) {
                 if (!isset($documentMap[$indexName])) {

--- a/src/Service/AppSearch/AppSearchService.php
+++ b/src/Service/AppSearch/AppSearchService.php
@@ -164,10 +164,11 @@ class AppSearchService implements IndexingInterface
 
     /**
      * @return int
+     * @throws IndexingServiceException
      */
     public function getMaxDocumentSize(): int
     {
-        return $this->getConfiguration()->get('max_document_size');
+        return $this->getConfiguration()->getMaxDocumentSize();
     }
 
     /**

--- a/src/Service/AppSearch/AppSearchService.php
+++ b/src/Service/AppSearch/AppSearchService.php
@@ -83,9 +83,9 @@ class AppSearchService implements IndexingInterface
 
             $fields = $this->getBuilder()->toArray($item);
 
-            $documentMaxSize = $this->getConfiguration()->getDocumentMaxSize();
-            if ($documentMaxSize  && strlen(serialize($fields)) >= $documentMaxSize) {
-                trigger_error(sprintf(
+            $documentMaxSize = $this->getMaxDocumentSize();
+            if ($documentMaxSize  && strlen(json_encode($fields)) >= $documentMaxSize) {
+                throw new IndexingServiceException(sprintf(
                     'Document title: %s, Document class: %s, Document ID %s: exceeds maximum allowed document size of %s bytes',
                     $fields['title'],
                     $fields['source_class'],
@@ -160,6 +160,14 @@ class AppSearchService implements IndexingInterface
         }
 
         return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaxDocumentSize(): int
+    {
+        return $this->getConfiguration()->get('max_document_size');
     }
 
     /**

--- a/src/Service/AppSearch/AppSearchService.php
+++ b/src/Service/AppSearch/AppSearchService.php
@@ -85,6 +85,8 @@ class AppSearchService implements IndexingInterface
 
             $documentMaxSize = $this->getMaxDocumentSize();
             if ($documentMaxSize  && strlen(json_encode($fields)) >= $documentMaxSize) {
+
+                // Todo: Display to the user that this record was not indexed.
                 throw new IndexingServiceException(sprintf(
                     'Document title: %s, Document class: %s, Document ID %s: exceeds maximum allowed document size of %s bytes',
                     $fields['title'],

--- a/src/Service/AppSearch/AppSearchService.php
+++ b/src/Service/AppSearch/AppSearchService.php
@@ -36,6 +36,12 @@ class AppSearchService implements IndexingInterface
     private $builder;
 
     /**
+     * @var int
+     * @config
+     */
+    private static $max_document_size = 102400;
+
+    /**
      * AppSearchService constructor.
      * @param Client $client
      * @param IndexConfiguration $configuration
@@ -82,20 +88,6 @@ class AppSearchService implements IndexingInterface
             }
 
             $fields = $this->getBuilder()->toArray($item);
-
-            $documentMaxSize = $this->getMaxDocumentSize();
-            if ($documentMaxSize  && strlen(json_encode($fields)) >= $documentMaxSize) {
-
-                // Todo: Display to the user that this record was not indexed.
-                throw new IndexingServiceException(sprintf(
-                    'Document title: %s, Document class: %s, Document ID %s: exceeds maximum allowed document size of %s bytes',
-                    $fields['title'],
-                    $fields['source_class'],
-                    $fields['record_id'],
-                    $documentMaxSize
-                ), E_USER_WARNING);
-                continue;
-            }
 
             $indexes = $this->getConfiguration()->getIndexesForDocument($item);
             foreach (array_keys($indexes) as $indexName) {
@@ -166,11 +158,10 @@ class AppSearchService implements IndexingInterface
 
     /**
      * @return int
-     * @throws IndexingServiceException
      */
     public function getMaxDocumentSize(): int
     {
-        return $this->getConfiguration()->getMaxDocumentSize();
+        return $this->config()->get('max_document_size');
     }
 
     /**

--- a/src/Service/DocumentBuilder.php
+++ b/src/Service/DocumentBuilder.php
@@ -90,13 +90,17 @@ class DocumentBuilder
 
         if ($documentMaxSize  && strlen(json_encode($data)) >= $documentMaxSize) {
             while (strlen(json_encode($data)) >= $documentMaxSize) {
-                // Sort the array so the longest value is always on top.
-                uasort($data, function($a, $b) {
-                    return strlen(json_encode($b)) - strlen(json_encode($a));
-                });
+                $max = 0;
+                $key = '';
+                foreach($data as $k => $v) {
+                    $size = strlen(json_encode($v));
+                    if ($size > $max) {
+                        $max = $size;
+                        $key = $k;
+                    }
+                }
 
-                $item = array_slice($data, 0, 1, true);
-                $data[key($item)] = substr(current($item), 0, -(strlen(current($item)) / 2));
+                $data[$key] = substr($data[$key], 0, -(strlen($data[$key]) / 2));
             }
         }
 

--- a/src/Service/DocumentBuilder.php
+++ b/src/Service/DocumentBuilder.php
@@ -27,8 +27,7 @@ class DocumentBuilder
     public function __construct(
         IndexConfiguration $configuration,
         DocumentFetchCreatorRegistry $registry
-    )
-    {
+    ) {
         $this->setConfiguration($configuration);
         $this->setRegistry($registry);
     }
@@ -92,7 +91,7 @@ class DocumentBuilder
             while (strlen(json_encode($data)) >= $documentMaxSize) {
                 $max = 0;
                 $key = '';
-                foreach($data as $k => $v) {
+                foreach ($data as $k => $v) {
                     $size = strlen(json_encode($v));
                     if ($size > $max) {
                         $max = $size;

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -69,10 +69,10 @@ class IndexConfiguration
     private static $source_class_field = 'source_class';
 
     /**
-     * @var int|null
+     * @var int
      * @config
      */
-    private static $document_max_size;
+    private static $max_document_size = 102400;
 
     /**
      * @var string|null
@@ -197,9 +197,9 @@ class IndexConfiguration
     /**
      * @return int|null
      */
-    public function getDocumentMaxSize(): ?int
+    public function getMaxDocumentSize(): ?int
     {
-        return $this->config()->get('document_max_size');
+        return $this->config()->get('max_document_size');
     }
 
     /**

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -69,10 +69,15 @@ class IndexConfiguration
     private static $source_class_field = 'source_class';
 
     /**
+     * @var int|null
+     * @config
+     */
+    private static $document_max_size;
+
+    /**
      * @var string|null
      */
     private $indexVariant;
-
 
     /**
      * @var bool
@@ -187,6 +192,14 @@ class IndexConfiguration
     public function shouldTrackDependencies(): bool
     {
         return $this->config()->get('auto_dependency_tracking');
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDocumentMaxSize(): ?int
+    {
+        return $this->config()->get('document_max_size');
     }
 
     /**

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -195,9 +195,9 @@ class IndexConfiguration
     }
 
     /**
-     * @return int|null
+     * @return int
      */
-    public function getMaxDocumentSize(): ?int
+    public function getMaxDocumentSize(): int
     {
         return $this->config()->get('max_document_size');
     }

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -69,12 +69,6 @@ class IndexConfiguration
     private static $source_class_field = 'source_class';
 
     /**
-     * @var int
-     * @config
-     */
-    private static $max_document_size = 102400;
-
-    /**
      * @var string|null
      */
     private $indexVariant;
@@ -192,14 +186,6 @@ class IndexConfiguration
     public function shouldTrackDependencies(): bool
     {
         return $this->config()->get('auto_dependency_tracking');
-    }
-
-    /**
-     * @return int
-     */
-    public function getMaxDocumentSize(): int
-    {
-        return $this->config()->get('max_document_size');
     }
 
     /**

--- a/tests/Fake/ServiceFake.php
+++ b/tests/Fake/ServiceFake.php
@@ -15,6 +15,8 @@ class ServiceFake implements IndexingInterface
 
     public $documents = [];
 
+    public $maxDocSize = 1000;
+
     public function addDocument(DocumentInterface $item): IndexingInterface
     {
         $this->documents[$item->getIdentifier()] = DocumentBuilder::singleton()->toArray($item);
@@ -88,5 +90,10 @@ class ServiceFake implements IndexingInterface
     public function validateField(string $field): void
     {
         return;
+    }
+
+    public function getMaxDocumentSize(): int
+    {
+        return $this->maxDocSize;
     }
 }


### PR DESCRIPTION
Elastic has a maximum document size they will index. Added a config variable to prevent trying to index documents that will be rejected by search providers. A warning is thrown with the details of any document that is bigger than the defined size.