### PR TITLE
FIX: Wrap requireDefaultRecords in a try-catch

### DIFF
--- a/src/Extensions/SearchServiceExtension.php
+++ b/src/Extensions/SearchServiceExtension.php
@@ -79,9 +79,14 @@ class SearchServiceExtension extends DataExtension
      */
     public function requireDefaultRecords()
     {
-        if (!$this->hasConfigured) {
-            $this->getIndexService()->configure();
-            $this->hasConfigured = true;
+        // Wrap this in a try-catch so that dev/build can continue (with warnings) when APP_SEARCH_ENDPOINT isn't set
+        try {
+            if (!$this->hasConfigured) {
+                $this->getIndexService()->configure();
+                $this->hasConfigured = true;
+            }
+        } catch (Exception $e) {
+            user_error(sprintf('Unable to configure search indexes: %s', $e->getMessage()), E_USER_WARNING);
         }
     }
     /**


### PR DESCRIPTION
This prevents failures on the CLI and in unit tests when running dev/build when Elastic vars aren't set to valid values