### PR TITLE
NEW: Add default implementation for search which does nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ composer require "silverstripe/silverstripe-search-service"
 * silverstripe/versioned
 * symbiote/silverstripe-queuedjobs
 
-## 🚨 Before using 🚨
-
-You must select which search service you will use after installing this module. If left undefined,
-your `dev/build` process will throw a runtime error. See the [implementations documentation](docs/en/implementations.md) for more information about how to activate a search service.
-
 ## Documentation
 
 See the [developer documentation](docs/en/index.md).

--- a/_config/appsearch.yml
+++ b/_config/appsearch.yml
@@ -4,6 +4,7 @@ Only:
   envvarset: 'APP_SEARCH_API_KEY'
 After:
   - 'silverstripe-search-service-dataobject'
+  - 'search-service-default'
 ---
 SilverStripe\Core\Injector\Injector:
   SilverStripe\SearchService\Interfaces\IndexingInterface:
@@ -26,4 +27,3 @@ SilverStripe\SearchService\DataObject\DataObjectDocument:
   id_field: record_id
   base_class_field: record_base_class
   page_content_field: page_content
-

--- a/_config/default.yml
+++ b/_config/default.yml
@@ -1,0 +1,6 @@
+---
+Name: search-service-default
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\SearchService\Interfaces\IndexingInterface:
+    class: SilverStripe\SearchService\Services\Naive\NaiveSearchService

--- a/docs/en/implementations.md
+++ b/docs/en/implementations.md
@@ -3,9 +3,17 @@
 This module is a set of abstractions for creating search-as-a-service integrations. This section
 of the documentation covers the details of each one.
 
+## Naive search
+
+This is the service that is enabled by default. It does not interact with any specific service, and is
+there to fill the whole in the abstraction layer when search is not yet being used. It is also a good option
+to have enabled when running tests and/or doing CI builds.
+
 ## Elastic AppSearch
 
-This module comes bundled with an implementation for [Elastic AppSearch](https://www.elastic.co/app-search/). While most of the details are abstracted away in the `AppSearchService` class, there are some key things to know about configuring AppSearch.
+This module comes bundled with an implementation for [Elastic AppSearch](https://www.elastic.co/app-search/).
+While most of the details are abstracted away in the `AppSearchService` class, there are some key things to
+know about configuring AppSearch.
 
 ### Activating AppSearch
 
@@ -43,14 +51,11 @@ SilverStripe\SearchService\Service\IndexConfiguration:
 ```
 
 **Note**: Be careful about whimsically changing your schema. AppSearch may need to be fully
-reindexed if you change the data type of a field. 
+reindexed if you change the data type of a field.
 
 ## More information
 
 * [Usage](usage.md)
 * [Configuration](configuration.md)
-* [Customising and extending](customising.md) 
+* [Customising and extending](customising.md)
 * [Overview and Rationale](overview.md)
-
-
-

--- a/src/Service/Naive/NaiveSearchService.php
+++ b/src/Service/Naive/NaiveSearchService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SilverStripe\SearchService\Services\Naive;
+
+use SilverStripe\SearchService\Interfaces\BatchDocumentInterface;
+use SilverStripe\SearchService\Interfaces\DocumentInterface;
+use SilverStripe\SearchService\Interfaces\IndexingInterface;
+
+class NaiveSearchService implements IndexingInterface
+{
+    public function addDocument(DocumentInterface $item): IndexingInterface
+    {
+        return $this;
+    }
+
+    public function addDocuments(array $items): BatchDocumentInterface
+    {
+        return $this;
+    }
+
+    public function removeDocuments(array $items): BatchDocumentInterface
+    {
+        return $this;
+    }
+
+    public function getDocuments(array $ids): array
+    {
+        return [];
+    }
+
+    public function listDocuments(string $indexName, ?int $limit = null, int $offset = 0): array
+    {
+        return [];
+    }
+
+    public function validateField(string $field): void
+    {
+        return;
+    }
+
+    public function configure(): void
+    {
+        return;
+    }
+
+    public function getDocument(string $id): ?DocumentInterface
+    {
+        return null;
+    }
+
+    public function getDocumentTotal(string $indexName): int
+    {
+        return 0;
+    }
+
+    public function removeDocument(DocumentInterface $doc): IndexingInterface
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
This allows devs to install the module locally while not being required to setup Elastic App Search.
Also useful for CI pipelines/unit testing

Resolves #31 