### PR TITLE
add use_absolute_links config option for PageCrawler

### DIFF
--- a/src/Service/PageCrawler.php
+++ b/src/Service/PageCrawler.php
@@ -46,7 +46,7 @@ class PageCrawler
 
         $page = null;
         try {
-            $response = Director::test($item->Link());
+            $response = Director::test($item->AbsoluteLink());
             $page = $response->getBody();
         } catch (Exception $e) {
             Injector::inst()->create(LoggerInterface::class)->error($e);


### PR DESCRIPTION
Fixes an issue with subsites where `$item->Link()` would return the relative link, resulting in the wrong page content (or no page content) being indexed.

Configured via:

```yaml
SilverStripe\SearchService\Service\PageCrawler:
  use_absolute_links: true
```

Some discussion to be had, maybe we should just be using `->AbsoluteLink()` regardless? Is there any harm in that?