### PR TITLE
add stub getMaxDocumentSize method to naive search

### DIFF
--- a/src/Service/Naive/NaiveSearchService.php
+++ b/src/Service/Naive/NaiveSearchService.php
@@ -57,4 +57,9 @@ class NaiveSearchService implements IndexingInterface
     {
         return $this;
     }
+
+    public function getMaxDocumentSize(): int
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
Will be required when #27 is merged, but I can't commit straight to that branch