### PR TITLE
Change DBDate Format to Rfc3339

### DIFF
--- a/src/Extensions/DBDateExtension.php
+++ b/src/Extensions/DBDateExtension.php
@@ -9,6 +9,6 @@ class DBDateExtension extends Extension
 {
     public function getSearchValue()
     {
-        return $this->owner->getTimestamp();
+        return $this->owner->Rfc3339();
     }
 }


### PR DESCRIPTION
Elastic doesn't actually accept timestamp when indexing content, only when searching:

https://www.elastic.co/guide/en/app-search/current/api-reference.html#overview-api-references-date

Trying to submit as a timestamp will result in the error:

`Invalid field value: Value '1533038400' cannot be parsed as a date (RFC 3339)`

Possibly should only overwrite for Elastic, but we'll see