### PR TITLE
add test for shouldIndex on versioned DO

### DIFF
--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -140,6 +140,11 @@ class DataObjectDocument implements
             return false;
         }
 
+        // Dataobject is only in draft
+        if ($dataObject->hasExtension(Versioned::class) && !$dataObject->isLiveVersion()) {
+            return false;
+        }
+
         // Indexing is globally disabled
         if (!$this->getConfiguration()->isEnabled()) {
             return false;

--- a/tests/Fake/VersionedDataObjectFake.php
+++ b/tests/Fake/VersionedDataObjectFake.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SilverStripe\SearchService\Tests\Fake;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\SearchService\Extensions\SearchServiceExtension;
+use SilverStripe\Versioned\Versioned;
+
+class VersionedDataObjectFake extends DataObject implements TestOnly
+{
+    private static $table_name = 'VersionedDataObjectFake';
+
+    private static $extensions = [
+        Versioned::class,
+        SearchServiceExtension::class,
+    ];
+
+    public $can_view;
+
+    private static $db = [
+        'ShowInSearch' => 'Boolean',
+    ];
+
+    public function canView($member = null)
+    {
+        if (is_callable($this->can_view)) {
+            $func = $this->can_view;
+            return $func();
+        }
+        return $this->can_view;
+    }
+}


### PR DESCRIPTION
Fixes #42 

Prevents draft content (or out of date Live content) being indexed via explicit check in `shouldIndex()`