### PR TITLE
add shouldFallbackToLatestVersion for DataObjectDocument

### DIFF
--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -588,7 +588,7 @@ class DataObjectDocument implements
     {
         $data = unserialize($serialized);
         $dataObject = DataObject::get_by_id($data['className'], $data['id']);
-        if (!$dataObject && $data['fallback']) {
+        if (!$dataObject && DataObject::has_extension($data['className'], Versioned::class) && $data['fallback']) {
             // get the latest version - usually this is an object that has been deleted
             $dataObject = Versioned::get_latest_version(
                 $data['className'],

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -83,6 +83,11 @@ class DataObjectDocument implements
     private $pageCrawler;
 
     /**
+     * @var bool
+     */
+    private $shouldFallbackToLatestVersion = false;
+
+    /**
      * @var array
      */
     private static $dependencies = [
@@ -117,6 +122,17 @@ class DataObjectDocument implements
     public function getSourceClass(): string
     {
         return $this->getDataObject()->ClassName;
+    }
+
+    /**
+     * @param bool $fallback
+     * @return $this
+     */
+    public function setShouldFallbackToLatestVersion(bool $fallback = true): DataObjectDocument
+    {
+        $this->shouldFallbackToLatestVersion = $fallback;
+
+        return $this;
     }
 
     /**
@@ -560,6 +576,7 @@ class DataObjectDocument implements
         return serialize([
             'className' => $this->getDataObject()->baseClass(),
             'id' => $this->getDataObject()->ID,
+            'fallback' => $this->shouldFallbackToLatestVersion,
         ]);
     }
 
@@ -571,8 +588,15 @@ class DataObjectDocument implements
     {
         $data = unserialize($serialized);
         $dataObject = DataObject::get_by_id($data['className'], $data['id']);
-        if (!$dataObject) {
-            throw new Exception(sprintf('DataObject %s : %s does not exist', $data['className'], $data['id']));
+        if (!$dataObject && $data['fallback']) {
+            // get the latest version - usually this is an object that has been deleted
+            $dataObject = Versioned::get_latest_version(
+                $data['className'],
+                $data['id']
+            );
+            if (!$dataObject) {
+                throw new Exception(sprintf('DataObject %s : %s does not exist', $data['className'], $data['id']));
+            }
         }
         $this->setDataObject($dataObject);
         foreach (static::config()->get('dependencies') as $name => $service) {

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -575,7 +575,7 @@ class DataObjectDocument implements
     {
         return serialize([
             'className' => $this->getDataObject()->baseClass(),
-            'id' => $this->getDataObject()->ID,
+            'id' => $this->getDataObject()->ID ?: $this->getDataObject()->OldID,
             'fallback' => $this->shouldFallbackToLatestVersion,
         ]);
     }
@@ -594,9 +594,9 @@ class DataObjectDocument implements
                 $data['className'],
                 $data['id']
             );
-            if (!$dataObject) {
-                throw new Exception(sprintf('DataObject %s : %s does not exist', $data['className'], $data['id']));
-            }
+        }
+        if (!$dataObject) {
+            throw new Exception(sprintf('DataObject %s : %s does not exist', $data['className'], $data['id']));
         }
         $this->setDataObject($dataObject);
         foreach (static::config()->get('dependencies') as $name => $service) {

--- a/src/Extensions/SearchServiceExtension.php
+++ b/src/Extensions/SearchServiceExtension.php
@@ -105,7 +105,7 @@ class SearchServiceExtension extends DataExtension
      */
     public function removeFromIndexes(): void
     {
-        $document = DataObjectDocument::create($this->owner);
+        $document = DataObjectDocument::create($this->owner)->setShouldFallbackToLatestVersion();
         $this->getBatchProcessor()->removeDocuments([$document]);
     }
 

--- a/src/Jobs/RemoveDataObjectJob.php
+++ b/src/Jobs/RemoveDataObjectJob.php
@@ -30,6 +30,10 @@ class RemoveDataObjectJob extends IndexJob
     {
         parent::__construct([], Indexer::METHOD_ADD, $batchSize);
         $this->timestamp = $timestamp ?: DBDatetime::now()->getTimestamp();
+        if ($document !== null) {
+            // We do this so that if the Dataobject is deleted, not just unpublished, we can still act upon it
+            $document->setShouldFallbackToLatestVersion();
+        }
         $this->document = $document;
     }
 

--- a/tests/Fake/DataObjectFakeVersioned.php
+++ b/tests/Fake/DataObjectFakeVersioned.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace SilverStripe\SearchService\Tests\Fake;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\SearchService\Extensions\SearchServiceExtension;
+use SilverStripe\Versioned\Versioned;
+
+class DataObjectFakeVersioned extends DataObject implements TestOnly
+{
+    private static $table_name = 'DataObjectFakeVersioned';
+
+    private static $extensions = [
+        SearchServiceExtension::class,
+        Versioned::class,
+    ];
+
+    private static $db = [
+        'Title' => 'Varchar',
+    ];
+}

--- a/tests/fixtures.yml
+++ b/tests/fixtures.yml
@@ -43,3 +43,8 @@ SilverStripe\SearchService\Tests\Fake\DataObjectFake:
     Tags: =>SilverStripe\SearchService\Tests\Fake\TagFake.one
     Member: =>SilverStripe\Security\Member.three
     Sort: 3
+
+SilverStripe\SearchService\Tests\Fake\DataObjectFakeVersioned:
+  one:
+    ID: 123
+    Title: Dataobject one Versioned


### PR DESCRIPTION
Adds provisioning for falling back to finding the latest version of a `DataObject` that may not exist any more. Fixes #49 by looking up the previously published version of the `DataObject` for its relations and data