### PR TITLE
API: Remove the 5 minute cooldown on DataObject fetching and indexing

### DIFF
--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -127,14 +127,6 @@ Let's look at all the settings on the `IndexConfiguration` class:
             <td>100</td>
         </tr>
         <tr>
-            <td>sync_interval</td>
-            <td>string</td>
-            <td>The minimum amount of time a document can be stale before it should be reindexed.
-                Only applies to bulk reindexing.
-            </td>
-            <td>"5 minutes"</td>
-        </tr>
-        <tr>
             <td>crawl_page_content</td>
             <td>bool</td>
             <td>If true, attempt to render pages in a controller and extract their content

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -380,7 +380,7 @@ class DataObjectDocument implements
             $fields = $this->getConfiguration()->getFieldsForClass($class);
 
             $registry = DocumentFetchCreatorRegistry::singleton();
-            $fetcher = $registry->getFetcher($class, time());
+            $fetcher = $registry->getFetcher($class);
             if (!$fetcher) {
                 continue;
             }

--- a/src/DataObject/DataObjectFetchCreator.php
+++ b/src/DataObject/DataObjectFetchCreator.php
@@ -23,11 +23,10 @@ class DataObjectFetchCreator implements DocumentFetchCreatorInterface
 
     /**
      * @param string $class
-     * @param int|null $since
      * @return DocumentFetcherInterface
      */
-    public function createFetcher(string $class, ?int $since = null): DocumentFetcherInterface
+    public function createFetcher(string $class): DocumentFetcherInterface
     {
-        return DataObjectFetcher::create($class, $since);
+        return DataObjectFetcher::create($class);
     }
 }

--- a/src/DataObject/DataObjectFetcher.php
+++ b/src/DataObject/DataObjectFetcher.php
@@ -30,11 +30,6 @@ class DataObjectFetcher implements DocumentFetcherInterface
     private $dataObjectClass;
 
     /**
-     * @var int|null
-     */
-    private $until;
-
-    /**
      * @var array
      */
     private static $dependencies = [
@@ -45,9 +40,8 @@ class DataObjectFetcher implements DocumentFetcherInterface
     /**
      * DataObjectFetcher constructor.
      * @param string $class
-     * @param int|null $until
      */
-    public function __construct(string $class, ?int $until = null)
+    public function __construct(string $class)
     {
         if (!is_subclass_of($class, DataObject::class)) {
             throw new InvalidArgumentException(sprintf(
@@ -58,7 +52,6 @@ class DataObjectFetcher implements DocumentFetcherInterface
         }
 
         $this->dataObjectClass = $class;
-        $this->until = $until;
     }
 
     /**
@@ -117,14 +110,7 @@ class DataObjectFetcher implements DocumentFetcherInterface
      */
     private function createDataList(?int $limit = null, ?int $offset = null): DataList
     {
-        /* @var DBDatetime $since */
-        $since = DBField::create_field('Datetime', $this->until);
-        $date = $since->Rfc2822();
-        $list = DataList::create($this->dataObjectClass)
-            ->where(
-                ['SearchIndexed IS NULL OR SearchIndexed < ?' => $date]
-            );
-
+        $list = DataList::create($this->dataObjectClass);
         return $list->limit($limit, $offset);
     }
 }

--- a/src/Interfaces/DocumentFetchCreatorInterface.php
+++ b/src/Interfaces/DocumentFetchCreatorInterface.php
@@ -13,8 +13,7 @@ interface DocumentFetchCreatorInterface
 
     /**
      * @param string $class
-     * @param int|null $until
      * @return DocumentFetcherInterface
      */
-    public function createFetcher(string $class, ?int $until = null): DocumentFetcherInterface;
+    public function createFetcher(string $class): DocumentFetcherInterface;
 }

--- a/src/Jobs/ReindexJob.php
+++ b/src/Jobs/ReindexJob.php
@@ -78,7 +78,6 @@ class ReindexJob extends AbstractQueuedJob implements QueuedJob
     public function setup()
     {
         Versioned::set_stage(Versioned::LIVE);
-        $until = strtotime('-' . $this->getConfiguration()->getSyncInterval());
         $classes = $this->onlyClasses && count($this->onlyClasses) ?
             $this->onlyClasses :
             $this->getConfiguration()->getSearchableBaseClasses();
@@ -86,7 +85,7 @@ class ReindexJob extends AbstractQueuedJob implements QueuedJob
         /* @var DocumentFetcherInterface[] $fetchers */
         $fetchers = [];
         foreach ($classes as $class) {
-            $fetcher = $this->getRegistry()->getFetcher($class, $until);
+            $fetcher = $this->getRegistry()->getFetcher($class);
             if ($fetcher) {
                 $fetchers[$class] = $fetcher;
             }

--- a/src/Service/DocumentFetchCreatorRegistry.php
+++ b/src/Service/DocumentFetchCreatorRegistry.php
@@ -56,14 +56,13 @@ class DocumentFetchCreatorRegistry
 
     /**
      * @param string $class
-     * @param int|null $until
      * @return DocumentFetchCreatorInterface|null
      */
-    public function getFetcher(string $class, ?int $until = null): ?DocumentFetcherInterface
+    public function getFetcher(string $class): ?DocumentFetcherInterface
     {
         foreach ($this->fetchCreators as $creator) {
             if ($creator->appliesTo($class)) {
-                return $creator->createFetcher($class, $until);
+                return $creator->createFetcher($class);
             }
         }
 

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -28,12 +28,6 @@ class IndexConfiguration
     private static $batch_size = 100;
 
     /**
-     * @var string
-     * @config
-     */
-    private static $sync_interval = '5 minutes';
-
-    /**
      * @var bool
      * @config
      */
@@ -102,14 +96,6 @@ class IndexConfiguration
     public function getBatchSize(): int
     {
         return $this->config()->get('batch_size');
-    }
-
-    /**
-     * @return string
-     */
-    public function getSyncInterval(): string
-    {
-        return $this->config()->get('sync_interval');
     }
 
     /**

--- a/tests/DataObject/DataObjectFetcherTest.php
+++ b/tests/DataObject/DataObjectFetcherTest.php
@@ -16,12 +16,6 @@ class DataObjectFetcherTest extends SearchServiceTest
         DataObjectFake::class
     ];
 
-    public function testConstructor()
-    {
-        $this->expectException('InvalidArgumentException');
-        DataObjectFetcher::create(Controller::class);
-    }
-
     public function testFetch()
     {
         $fetcher = DataObjectFetcher::create(DataObjectFake::class);

--- a/tests/Fake/FakeFetchCreator.php
+++ b/tests/Fake/FakeFetchCreator.php
@@ -13,7 +13,7 @@ class FakeFetchCreator implements DocumentFetchCreatorInterface
         return $type === 'Fake';
     }
 
-    public function createFetcher(string $class, ?int $until = null): DocumentFetcherInterface
+    public function createFetcher(string $class): DocumentFetcherInterface
     {
         return new FakeFetcher();
     }

--- a/tests/Fake/IndexConfigurationFake.php
+++ b/tests/Fake/IndexConfigurationFake.php
@@ -26,11 +26,6 @@ class IndexConfigurationFake extends IndexConfiguration
         return $this->override['batch_size'] ?? parent::getBatchSize();
     }
 
-    public function getSyncInterval(): string
-    {
-        return $this->override['sync_interval'] ?? parent::getSyncInterval();
-    }
-
     public function shouldCrawlPageContent(): bool
     {
         return $this->override['crawl_page_content'] ?? parent::shouldCrawlPageContent();


### PR DESCRIPTION
This removes the (by default) 5 minute limit for searching / indexing content, ensuring that when you run `SearchReindex` you get all content re-indexed no matter what. This also ensures that aren't any holes (e.g. where you publish a page and the reindex of that page happens within the same second, but fails because the timestamp is slightly earlier than the last time it was 'indexed').

The main issue here is running `SearchReindex` a couple of times in quick succession results in a variable number of documents being indexed, and other documents that were previously indexed being removed because they're not in the list of fetched objects as they were indexed too recently.

I've also removed this from all the interfaces, classes etc, however I have left this in the documentation for creating a new `DataObjectFetcher` as it could be relevant for other types of fetchers (and I presume that it's okay to extend interfaces with additional variables).

Happy to cut this down to a much simpler PR that just removes the offending lines inside `DataObjectFetcher::createDataList()` if you'd prefer, that would leave all the rest of the config but just not do anything with it for `DataObject`s.