### PR TITLE
FIX ensure the ClearIndexJob doesn't break during initialisation

### DIFF
--- a/src/Jobs/ClearIndexJob.php
+++ b/src/Jobs/ClearIndexJob.php
@@ -37,12 +37,17 @@ class ClearIndexJob extends AbstractQueuedJob implements QueuedJob
 
     /**
      * ClearIndexJob constructor.
-     * @param string $indexName
+     * @param string|null $indexName
      * @param int|null $batchSize
      */
-    public function __construct(string $indexName, ?int $batchSize = null)
+    public function __construct(?string $indexName = null, ?int $batchSize = null)
     {
         parent::__construct();
+
+        if (!$indexName) {
+            return;
+        }
+
         $this->indexName = $indexName;
         $this->batchSize = $batchSize ?: IndexConfiguration::singleton()->getBatchSize();
         $this->batchOffset = 0;


### PR DESCRIPTION
QueuedJobs requires default values to be set in __construct which causes this job to be stuck in "Initialising" https://github.com/symbiote/silverstripe-queuedjobs/blob/89a057ce2c7e2f9560b8eea6d1974f423f45dc8b/docs/en/defining-jobs.md#api-overview