### PR TITLE
Fix removal of documents from index when they no longer exist in Silverstripe

### DIFF
--- a/src/Interfaces/BatchDocumentRemovalInterface.php
+++ b/src/Interfaces/BatchDocumentRemovalInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\SearchService\Interfaces;
+
+interface BatchDocumentRemovalInterface
+{
+    /**
+     * @return int The number of removed documents from this call (should equal the previous total number of documents)
+     */
+    public function removeAllDocuments(string $indexName): int;
+}

--- a/src/Jobs/ClearIndexJob.php
+++ b/src/Jobs/ClearIndexJob.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\SearchService\Exception\IndexingServiceException;
+use SilverStripe\SearchService\Interfaces\BatchDocumentRemovalInterface;
 use SilverStripe\SearchService\Interfaces\IndexingInterface;
 use SilverStripe\SearchService\Service\IndexConfiguration;
 use SilverStripe\SearchService\Service\Traits\ServiceAware;
@@ -77,10 +78,11 @@ class ClearIndexJob extends AbstractQueuedJob implements QueuedJob
         Environment::increaseMemoryLimitTo();
         Environment::increaseTimeLimitTo();
 
-        if (!method_exists($this->getIndexService(), 'removeAllDocuments')) {
+        if (!$this->getIndexService() instanceof BatchDocumentRemovalInterface) {
             Injector::inst()->get(LoggerInterface::class)->error(sprintf(
-                'Index service "%s" does not implement the BatchDocumentRemovalInterface, cannot remove all documents',
-                get_class($this->getIndexService())
+                'Index service "%s" does not implement the %s interface. Cannot remove all documents',
+                get_class($this->getIndexService()),
+                BatchDocumentRemovalInterface::class
             ));
 
             $this->isComplete = true;

--- a/src/Service/BatchProcessor.php
+++ b/src/Service/BatchProcessor.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace SilverStripe\SearchService\Service;
 
 use SilverStripe\Core\Injector\Injectable;

--- a/src/Service/Naive/NaiveSearchService.php
+++ b/src/Service/Naive/NaiveSearchService.php
@@ -3,10 +3,11 @@
 namespace SilverStripe\SearchService\Services\Naive;
 
 use SilverStripe\SearchService\Interfaces\BatchDocumentInterface;
+use SilverStripe\SearchService\Interfaces\BatchDocumentRemovalInterface;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
 use SilverStripe\SearchService\Interfaces\IndexingInterface;
 
-class NaiveSearchService implements IndexingInterface
+class NaiveSearchService implements IndexingInterface, BatchDocumentRemovalInterface
 {
     public function addDocument(DocumentInterface $item): IndexingInterface
     {
@@ -21,6 +22,11 @@ class NaiveSearchService implements IndexingInterface
     public function removeDocuments(array $items): BatchDocumentInterface
     {
         return $this;
+    }
+
+    public function removeAllDocuments(string $indexName): int
+    {
+        return 0;
     }
 
     public function getDocuments(array $ids): array

--- a/tests/Fake/ServiceFake.php
+++ b/tests/Fake/ServiceFake.php
@@ -4,11 +4,12 @@
 namespace SilverStripe\SearchService\Tests\Fake;
 
 use SilverStripe\SearchService\Interfaces\BatchDocumentInterface;
+use SilverStripe\SearchService\Interfaces\BatchDocumentRemovalInterface;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
 use SilverStripe\SearchService\Interfaces\IndexingInterface;
 use SilverStripe\SearchService\Service\DocumentBuilder;
 
-class ServiceFake implements IndexingInterface
+class ServiceFake implements IndexingInterface, BatchDocumentRemovalInterface
 {
 
     public $shouldError = false;
@@ -39,6 +40,18 @@ class ServiceFake implements IndexingInterface
         }
 
         return $this;
+    }
+
+    public function removeAllDocuments(string $indexName): int
+    {
+        if ($this->shouldError) {
+            return 0;
+        }
+        
+        $numDocs = sizeof($this->documents);
+        $this->documents = [];
+
+        return $numDocs;
     }
 
     public function removeDocument(DocumentInterface $doc): IndexingInterface

--- a/tests/Jobs/ClearIndexJobTest.php
+++ b/tests/Jobs/ClearIndexJobTest.php
@@ -3,6 +3,8 @@
 
 namespace SilverStripe\SearchService\Tests\Jobs;
 
+use InvalidArgumentException;
+use RuntimeException;
 use SilverStripe\SearchService\Jobs\ClearIndexJob;
 use SilverStripe\SearchService\Tests\Fake\DataObjectFake;
 use SilverStripe\SearchService\Tests\SearchServiceTest;
@@ -13,15 +15,50 @@ class ClearIndexJobTest extends SearchServiceTest
         DataObjectFake::class,
     ];
 
+    public function testConstruct()
+    {
+        $config = $this->mockConfig();
+
+        // Batch size of 0 is the same as not specifying a batch size, so we should get the batch size from config
+        $job = ClearIndexJob::create('myindex', 0);
+        $this->assertSame($config->getBatchSize(), $job->batchSize);
+
+        // Same with not specifying a batch size at all
+        $job = ClearIndexJob::create('myindex');
+        $this->assertSame($config->getBatchSize(), $job->batchSize);
+
+        // Specifying a batch size under 0 should throw an exception
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Batch size must be greater than 0');
+        $job = ClearIndexJob::create('myindex', -1);
+
+        // If no index name is provided, then other config options should not be applied
+        $job = ClearIndexJob::create();
+        $this->assertNull($job->indexName);
+        $this->assertNull($job->batchSize);
+        $this->assertNull($job->batchOffset);
+    }
+
     public function testSetup()
     {
         $config = $this->mockConfig();
         $config->set('crawl_page_content', false);
-        $this->loadIndex(20);
-        $job = ClearIndexJob::create('myindex', 6);
+        $this->loadIndex(10);
+        $job = ClearIndexJob::create('myindex', 1);
         $job->setup();
-        $this->assertEquals(4, $job->getJobData()->totalSteps);
+
+        // Total number of steps should always be 5 no matter the size of the index or batch size
+        $this->assertEquals(5, $job->getJobData()->totalSteps);
         $this->assertFalse($job->jobFinished());
+    }
+
+    public function testGetTitle()
+    {
+        $job = ClearIndexJob::create('indexName');
+        $this->assertContains('indexName', $job->getTitle());
+
+        $job = ClearIndexJob::create('random_index_name');
+        $this->assertContains('random_index_name', $job->getTitle());
     }
 
     public function testProcess()
@@ -29,23 +66,32 @@ class ClearIndexJobTest extends SearchServiceTest
         $config = $this->mockConfig();
         $config->set('crawl_page_content', false);
         $service = $this->loadIndex(20);
-        $job = ClearIndexJob::create('myindex', 6);
+        $job = ClearIndexJob::create('myindex', 5);
         $job->setup();
-
-        $job->process();
-        $this->assertFalse($job->jobFinished());
-        $this->assertEquals(14, $service->getDocumentTotal('myindex'));
-
-        $job->process();
-        $this->assertFalse($job->jobFinished());
-        $this->assertEquals(8, $service->getDocumentTotal('myindex'));
-
-        $job->process();
-        $this->assertFalse($job->jobFinished());
-        $this->assertEquals(2, $service->getDocumentTotal('myindex'));
 
         $job->process();
         $this->assertTrue($job->jobFinished());
         $this->assertEquals(0, $service->getDocumentTotal('myindex'));
+
+        // Now create a fake test where we don't remove any documents
+        $service = $this->loadIndex(10);
+        $service->shouldError = true;
+        $job = ClearIndexJob::create('myindex', 5);
+        $job->setup();
+
+        // We try to run up to 5 times before failing - the first 5 runs should process but not do anything...
+        $job->process();
+        $job->process();
+        $job->process();
+        $job->process();
+        $job->process();
+
+        // The 6th time we process should fail with a RuntimeException
+        $msg = 'ClearIndexJob was unable to delete all documents after 5 attempts. Finished all steps and the document'
+            .   ' total is still 10';
+        
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage($msg);
+        $job->process();
     }
 }

--- a/tests/Service/AppSearch/AppSearchServiceTest.php
+++ b/tests/Service/AppSearch/AppSearchServiceTest.php
@@ -115,6 +115,34 @@ class AppSearchServiceTest extends SearchServiceTest
 
         $this->appSearch->addDocuments([$fake1, $fake2]);
     }
+    
+    public function testRemoveAllDocuments()
+    {
+        $this->client->expects($this->exactly(2))
+            ->method('listDocuments')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    'results' => [
+                        [ 'id' => 100 ],
+                        [ 'id' => 101 ],
+                        [ 'id' => 102 ]
+                    ]
+                ],
+                [
+                    'results' => []
+                ]
+            );
+
+        $this->client->expects($this->exactly(1))
+            ->method('deleteDocuments')
+            ->willReturn([
+                [ 'deleted' => true ],
+                [ 'deleted' => true ],
+                [ 'deleted' => true ],
+            ]);
+
+        $this->assertSame(3, $this->appSearch->removeAllDocuments('test'));
+    }
 
     public function testRemoveDocuments()
     {


### PR DESCRIPTION
Fixes #36.

API changes:
- Add new BatchDocumentRemovalInterface interface and removeAllDocuments method
- Implement removeAllDocuments for AppSearchService, ServiceFake, and NaiveSearchService

Fixes:
- Fix ClearIndexJob so that it runs in a single job run (provided it can finish within limits), and retries up to 5 times
- Add messaging to ClearIndexJob so we know whether it succeeded or not

Tests:
- Add removeAllDocuments to ServiceFake
- Add new and fix existing ClearIndexJob tests