### PR TITLE
Make "removeAllDocuments" declaration compatible with older PHP versions

### DIFF
--- a/src/Service/AppSearch/AppSearchService.php
+++ b/src/Service/AppSearch/AppSearchService.php
@@ -164,7 +164,7 @@ class AppSearchService implements IndexingInterface, BatchDocumentRemovalInterfa
      * @param string $indexName The index name to remove all documents from
      * @return int The total number of documents removed
      */
-    public function removeAllDocuments($indexName): int
+    public function removeAllDocuments(string $indexName): int
     {
         $cfg = $this->getConfiguration();
         $client = $this->getClient();


### PR DESCRIPTION
On PHP 7.1 an exception is triggered because of incompatible method declaration for `removeAllDocuments` in the `AppSearchService`:
```
Declaration of SilverStripe\SearchService\Services\AppSearch\AppSearchService::removeAllDocuments($indexName): int 
must be compatible with 
SilverStripe\SearchService\Interfaces\BatchDocumentRemovalInterface::removeAllDocuments(string $indexName): int
```