### PR TITLE
BUGFIX ensure truncated strings are still json_encodeable

### DIFF
--- a/src/Service/DocumentBuilder.php
+++ b/src/Service/DocumentBuilder.php
@@ -22,7 +22,6 @@ class DocumentBuilder
      * DocumentBuilder constructor.
      * @param IndexConfiguration $configuration
      * @param DocumentFetchCreatorRegistry $registry
-     * @param IndexingInterface $service
      */
     public function __construct(
         IndexConfiguration $configuration,
@@ -51,9 +50,8 @@ class DocumentBuilder
         }
 
         $data[$sourceClassField] = $document->getSourceClass();
-        $data = $this->truncateDocument($data);
 
-        return $data;
+        return $this->truncateDocument($data);
     }
 
     /**
@@ -91,6 +89,7 @@ class DocumentBuilder
             while (strlen(json_encode($data)) >= $documentMaxSize) {
                 $max = 0;
                 $key = '';
+                // Determine which field is the largest, so we can halve that to have the most impact
                 foreach ($data as $k => $v) {
                     $size = strlen(json_encode($v));
                     if ($size > $max) {
@@ -99,7 +98,8 @@ class DocumentBuilder
                     }
                 }
 
-                $data[$key] = substr($data[$key], 0, -(strlen($data[$key]) / 2));
+                // Make sure we don't chop any characters in the middle making them UTF-8 invalid and non-jsonable
+                $data[$key] = mb_substr($data[$key], 0, -(mb_strlen($data[$key]) / 2));
             }
         }
 

--- a/tests/Service/DocumentBuilderTest.php
+++ b/tests/Service/DocumentBuilderTest.php
@@ -73,24 +73,40 @@ class DocumentBuilderTest extends SearchServiceTest
 
         $builder = DocumentBuilder::create();
         $document = new DocumentFake('Fake', [
-            'field1' => str_repeat('a', 500)
+            'field1' => str_repeat('a', 500),
         ]);
         $array = $builder->toArray($document);
-        $this->assertLessThanOrEqual($fake->maxDocSize, strlen(json_encode($array)));
+        $postData = json_encode($array, JSON_PRESERVE_ZERO_FRACTION);
+        $this->assertNotFalse($postData, 'Document failed to successfully json_encode');
+        $this->assertLessThanOrEqual($fake->maxDocSize, strlen($postData));
 
         $document = new DocumentFake('Fake', [
-            'field1' => str_repeat('a', 50)
+            'field1' => str_repeat('a', 50),
         ]);
 
         // Try a couple different doc sizes that far exceed the size of this document
         $fake->maxDocSize = 10000;
         $array = $builder->toArray($document);
-        $size1 = strlen(json_encode($array));
+        $postData = json_encode($array, JSON_PRESERVE_ZERO_FRACTION);
+        $this->assertNotFalse($postData, 'Document failed to successfully json_encode');
+        $size1 = strlen($postData);
 
         $fake->maxDocSize = 5000;
         $array = $builder->toArray($document);
-        $size2 = strlen(json_encode($array));
+        $postData = json_encode($array, JSON_PRESERVE_ZERO_FRACTION);
+        $this->assertNotFalse($postData, 'Document failed to successfully json_encode');
+        $size2 = strlen($postData);
 
         $this->assertEquals($size1, $size2);
+
+        // Try a non-latin document with awkward splits
+        $fake->maxDocSize = 53;
+        $document = new DocumentFake('Fake', [
+            'field1' => str_repeat('日', 117),
+        ]);
+        $array = $builder->toArray($document);
+        $postData = json_encode($array, JSON_PRESERVE_ZERO_FRACTION);
+        $this->assertNotFalse($postData, 'Document failed to successfully json_encode');
+        $this->assertLessThanOrEqual($fake->maxDocSize, strlen($postData));
     }
 }


### PR DESCRIPTION
Fixes an error I was seeing a lot:

```
[ERROR] Invalid request body provided {"exception":"[object] (InvalidArgumentException(code: 0): Invalid request body provided at /var/www/mysite/www/vendor/guzzlehttp/ringphp/src/Client/CurlFactory.php:289)"} []
```

It was coming from truncating content that was in Thai (amongst other languages) that would have characters cut through the middle, making them invalid UTF-8 and causing the `json_encode()` to fail when Guzzle was trying to compile the body to fire through to Elastic.

This PR checks that the `string` is `json_encode()`-able and nudges the truncate one char each loop until it is.