### PR TITLE
ENH Add extension to reindex parent page when elements are published

### DIFF
--- a/_config/elemental.yml
+++ b/_config/elemental.yml
@@ -1,0 +1,9 @@
+---
+Name: 'silverstripe-search-service-elemental'
+After: '#silverstripe-search-service'
+Only:
+  moduleexists: 'dnadesign/silverstripe-elemental'
+---
+DNADesign\Elemental\Models\BaseElement:
+  extensions:
+    - SilverStripe\SearchService\Extensions\Elemental\IndexParentPageExtension

--- a/src/Extensions/Elemental/IndexParentPageExtension.php
+++ b/src/Extensions/Elemental/IndexParentPageExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SilverStripe\SearchService\Extensions\Elemental;
+
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Extension;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\SearchService\Extensions\SearchServiceExtension;
+use SilverStripe\SearchService\Service\IndexConfiguration;
+use SilverStripe\Versioned\Versioned;
+
+class IndexParentPageExtension extends Extension
+{
+
+    /**
+     * Force a re-index of the parent page for any given element
+     * @param Versioned $original
+     */
+    public function onAfterPublish(&$original)
+    {
+        if (Config::inst()->get(IndexConfiguration::class, 'index_parent_page_of_elements') === true) {
+            /** @var DataObject $parent */
+            $parent = $this->getOwner()->getPage();
+            if ($parent && $parent->hasExtension(SearchServiceExtension::class)) {
+                $parent->addToIndexes();
+            }
+        }
+    }
+}

--- a/src/Extensions/Elemental/IndexParentPageExtension.php
+++ b/src/Extensions/Elemental/IndexParentPageExtension.php
@@ -9,6 +9,14 @@ use SilverStripe\SearchService\Extensions\SearchServiceExtension;
 use SilverStripe\SearchService\Service\IndexConfiguration;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * Extension class that hooks into BaseElement to ensure that the parent page is indexed whenever an element is
+ * published. This is necessary because Silverstripe CMS optimises away database write calls unless they are necessary,
+ * so even when you click 'Save' or 'Publish' on a page, the page won't be saved or published unless a direct db field
+ * on the page is changed.
+ *
+ * @codeCoverageIgnore
+ */
 class IndexParentPageExtension extends Extension
 {
 

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -81,6 +81,14 @@ class IndexConfiguration
     private static $auto_dependency_tracking = true;
 
     /**
+     * @var bool
+     * @config
+     *
+     * @link IndexParentPageExtension
+     */
+    private static $index_parent_page_of_elements = true;
+
+    /**
      * @var array
      */
     private $indexesForClassName = [];


### PR DESCRIPTION
Solves an issue where making a change to an element on a page doesn't push that change through to the reindexer, so content isn't up to date.

Behind a config flag and a module-exists check.