### PR TITLE
FIX: SearchIndexed field insertion was breaking on forms without tabs

### DIFF
--- a/src/Extensions/SearchServiceExtension.php
+++ b/src/Extensions/SearchServiceExtension.php
@@ -67,9 +67,13 @@ class SearchServiceExtension extends DataExtension
     public function updateCMSFields(FieldList $fields)
     {
         if ($this->getConfiguration()->isEnabled()) {
-            $fields->addFieldsToTab('Root.Main', [
-                ReadonlyField::create('SearchIndexed', _t(__CLASS__.'.LastIndexed', 'Last indexed in search'))
-            ]);
+            $field = ReadonlyField::create('SearchIndexed', _t(__CLASS__.'.LastIndexed', 'Last indexed in search'));
+
+            if ($fields->hasTabSet()) {
+                $fields->addFieldToTab('Root.Main', $field);
+            } else {
+                $fields->push($field);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #65.

I don't know of a more elegant way to do this. Previously we added the field to it's own tab called 'Search', but that doesn't work when we don't have a `TabSet` defined. For example, editing a `File` doesn't include tabs, it's just a list of data fields.

The thought here is that almost every object will have a `Title` field, so you'll get it on as many different objects as you want. Developers can always move the field around later if they want by removing and re-adding it themselves.