### PR TITLE
Index configuration overrides DO subsite field if NULL value

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,7 @@ jobs:
   ci:
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
     with:
+      composer_require_extra: silverstripe/subsites:^2.6
       dynamic_matrix: false
       extra_jobs: |
         - php: 8.0

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -27,7 +27,7 @@ on your service provider. For EnterpriseSearch, it should only contain lowercase
 and hyphens.
 
 * `includedClasses`: A list of content classes to index. These are just the _source_ of the
-content, so they have no contractual bind to the module. If they are dataobjects, they 
+content, so they have no contractual bind to the module. If they are dataobjects, they
 should have the `SearchServiceExtension` applied, however. This is discussed further below.
 
 * `SilverStripe\CMS\Model\SiteTree`: This class already has the necessary extension applied
@@ -81,8 +81,8 @@ SilverStripe\SearchService\Service\IndexConfiguration:
             property: 'Comments.Author.Name'
 ```
 
-For DataObject content, the dot syntax allows traversal of relationships. If the final 
-property in the notation is on a list, it will use the `->column()` function to derive 
+For DataObject content, the dot syntax allows traversal of relationships. If the final
+property in the notation is on a list, it will use the `->column()` function to derive
 the values as an array.
 
 This will roughly get indexed as a structure like this:
@@ -193,7 +193,7 @@ SilverStripe\Core\Injector\Injector:
     constructor:
       index_variant: '`MY_CUSTOM_VAR`'
 
-``` 
+```
 
 This is useful if you have multiple staging environments and you don't want to overcrowd
 your search instance with distinct indexes for each one.
@@ -201,7 +201,7 @@ your search instance with distinct indexes for each one.
 ## Full page indexing
 
 Page and DataObject content is eligible for full-page indexing of its content. This is
-predicated upon the object having a `Link()` method defined that can be rendered in a 
+predicated upon the object having a `Link()` method defined that can be rendered in a
 controller.
 
 The content is extracted using an XPath selector. By default, this is `//main`, but it
@@ -236,7 +236,7 @@ SilverStripe\SearchService\Service\IndexConfiguration:
             summary:
               property: Summary
     content-subsite4:
-      subsite_id: 4
+      subsite_id: 4 # or you can use environment variable such as 'NAME_OF_ENVIRONMENT_VARIABLE'
       includeClasses:
         Page:
           <<: *page_defaults
@@ -248,6 +248,9 @@ SilverStripe\SearchService\Service\IndexConfiguration:
 Note the syntax to reduce the need for copy-paste if you want to duplicate the
 same configuration across.
 
+__Additional note__:
+> In the sample above, if the data object (My\Other\Class) does not have a subsite ID,  then it will be included in the indexing as it is explicitly defined in the index configuration
+
 This is handled via `SubsiteIndexConfigurationExtension` - this logic could be
 replicated for other scenarios like languages if required.
 
@@ -255,5 +258,5 @@ replicated for other scenarios like languages if required.
 
 * [Usage](usage.md)
 * [Implementations](implementations.md)
-* [Customising and extending](customising.md) 
+* [Customising and extending](customising.md)
 * [Overview and Rationale](overview.md)

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -21,6 +21,7 @@ use SilverStripe\ORM\UnsavedRelationList;
 use SilverStripe\SearchService\Exception\IndexConfigurationException;
 use SilverStripe\SearchService\Extensions\DBFieldExtension;
 use SilverStripe\SearchService\Extensions\SearchServiceExtension;
+use SilverStripe\SearchService\Interfaces\DataObjectDocumentInterface;
 use SilverStripe\SearchService\Interfaces\DependencyTracker;
 use SilverStripe\SearchService\Interfaces\DocumentAddHandler;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
@@ -43,7 +44,8 @@ class DataObjectDocument implements
     DependencyTracker,
     DocumentRemoveHandler,
     DocumentAddHandler,
-    DocumentMetaProvider
+    DocumentMetaProvider,
+    DataObjectDocumentInterface
 {
 
     use Injectable;

--- a/src/Extensions/Subsites/IndexConfigurationExtension.php
+++ b/src/Extensions/Subsites/IndexConfigurationExtension.php
@@ -3,7 +3,7 @@
 namespace SilverStripe\SearchService\Extensions\Subsites;
 
 use SilverStripe\Core\Extension;
-use SilverStripe\SearchService\DataObject\DataObjectDocument;
+use SilverStripe\SearchService\Interfaces\DataObjectDocumentInterface;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
 
 class IndexConfigurationExtension extends Extension
@@ -11,16 +11,44 @@ class IndexConfigurationExtension extends Extension
 
     public function updateIndexesForDocument(DocumentInterface $doc, array &$indexes): void
     {
-        $docSubsiteId = null;
-
-        if ($doc instanceof DataObjectDocument) {
-            $docSubsiteId = $doc->getDataObject()->SubsiteID ?? null;
+        // Skip if document object does not implement DataObject interface
+        if (!$doc instanceof DataObjectDocumentInterface) {
+            return;
         }
 
+        $docSubsiteId = $doc->getDataObject()->SubsiteID ?? 0;
+
+        if ((int) $docSubsiteId === 0) {
+            $this->updateDocumentWithoutSubsite($doc, $indexes);
+        } else {
+            $this->updateDocumentWithSubsite($indexes, $docSubsiteId);
+        }
+    }
+
+    /**
+     * DataObject does not have a defined SubsiteID. So if the developer explicitly defined the dataObject to be
+     * included in the Subsite Index configuration then allow the dataObject to be added in.
+     */
+    protected function updateDocumentWithoutSubsite(DocumentInterface $doc, array &$indexes): void
+    {
+        foreach ($indexes as $indexName => $data) {
+            // DataObject explicitly defined on Subsite index definition
+            $explicitClasses = $data['includeClasses'] ?? [];
+
+            if (!isset($explicitClasses[$doc->getDataObject()->ClassName])) {
+                unset($indexes[$indexName]);
+
+                break;
+            }
+        }
+    }
+
+    protected function updateDocumentWithSubsite(array &$indexes, int $docSubsiteId): void
+    {
         foreach ($indexes as $indexName => $data) {
             $subsiteId = $data['subsite_id'] ?? 'all';
 
-            if ($subsiteId !== 'all' && $docSubsiteId !== $subsiteId) {
+            if ($subsiteId !== 'all' && $docSubsiteId !== (int)$subsiteId) {
                 unset($indexes[$indexName]);
             }
         }

--- a/src/Extensions/Subsites/SearchAdminExtension.php
+++ b/src/Extensions/Subsites/SearchAdminExtension.php
@@ -4,6 +4,7 @@ namespace SilverStripe\SearchService\Extensions\Subsites;
 
 use SilverStripe\Core\Extension;
 use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataQuery;
 use SilverStripe\Subsites\Model\Subsite;
 
@@ -20,7 +21,11 @@ class SearchAdminExtension extends Extension
             }
 
             Subsite::disable_subsite_filter(true);
-            $query->where(sprintf('SubsiteID = %s', $data['subsite_id']));
+
+            // If the DataObject has a Subsite relation, then apply a SubsiteID filter
+            if (DataObject::getSchema()->hasOneComponent(Subsite::class, 'Subsite')) {
+                $query->where(sprintf('SubsiteID IS NULL OR SubsiteID = %d', $data['subsite_id']));
+            }
         }
     }
 

--- a/src/Interfaces/DataObjectDocumentInterface.php
+++ b/src/Interfaces/DataObjectDocumentInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\SearchService\Interfaces;
+
+use SilverStripe\ORM\DataObject;
+
+/**
+ * The contract to indicate that the Elastic Document sources its data from Silverstripe DataObject class
+ */
+interface DataObjectDocumentInterface
+{
+
+    public function getDataObject(): DataObject;
+
+}

--- a/src/Service/IndexConfiguration.php
+++ b/src/Service/IndexConfiguration.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\SearchService\Service;
 
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Environment;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
@@ -94,6 +95,11 @@ class IndexConfiguration
     public function getIndexes(): array
     {
         $indexes = $this->config()->get('indexes');
+
+        // Convert environment variable defined in YML config to its value
+        array_walk($indexes, function (array &$configuration): void {
+            $configuration = $this->environmentVariableToValue($configuration);
+        });
 
         if (!$this->onlyIndexes) {
             return $indexes;
@@ -265,6 +271,28 @@ class IndexConfiguration
         }
 
         return $fields;
+    }
+
+    /**
+     * For every configuration item if value is environment variable then convert it to its value
+     */
+    protected function environmentVariableToValue(array $configuration): array
+    {
+        foreach ($configuration as $name => $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+
+            $environmentValue = Environment::getEnv($value);
+
+            if (!$environmentValue) {
+                continue;
+            }
+
+            $configuration[$name] = $environmentValue;
+        }
+
+        return $configuration;
     }
 
 }

--- a/tests/fixtures.yml
+++ b/tests/fixtures.yml
@@ -58,3 +58,9 @@ SilverStripe\SearchService\Tests\Fake\DataObjectFakeVersioned:
   two:
     Title: Dataobject two Versioned
     ShowInSearch: 0
+
+SilverStripe\Subsites\Model\Subsite:
+  subsite1:
+    Title: 'Subsite 1'
+  subsite2:
+    Title: 'Subsite 2'

--- a/tests/pages.yml
+++ b/tests/pages.yml
@@ -17,3 +17,7 @@ Page:
     Title: Child Page 3
     Parent: =>Page.page4
     ShowInSearch: 1
+  page6:
+    Title: Subsite Page 1
+    Subsite: =>SilverStripe\Subsites\Model\Subsite.subsite1
+    ShowInSearch: 1


### PR DESCRIPTION
Background:
 
DataObject does not have a SubsiteID field and is not being indexed even if explicitly defined in the Subsite Config.

Added Solution:
- Allow indexing of DO even if SubsiteID is not defined (null)
- Allow DO to be added on multiple Subsite search Index


```
App\Model\Product: &product_defaults
          fields:
            title:
              property: Title
            last_updated:
              property: LastUpdated
            code:
              property: Code
              options:
                type: text
```