### PR TITLE
FIX Update getters to return correct value types

### DIFF
--- a/src/Jobs/ClearIndexJob.php
+++ b/src/Jobs/ClearIndexJob.php
@@ -44,7 +44,7 @@ class ClearIndexJob extends AbstractQueuedJob implements QueuedJob
         $this->setBatchSize($batchSize);
         $this->setBatchOffset(0);
 
-        if ($this->getBatchSize() < 1) {
+        if (!$this->getBatchSize() || $this->getBatchSize() < 1) {
             throw new InvalidArgumentException('Batch size must be greater than 0');
         }
     }
@@ -111,16 +111,28 @@ class ClearIndexJob extends AbstractQueuedJob implements QueuedJob
 
     public function getBatchOffset(): ?int
     {
+        if (is_bool($this->batchOffset)) {
+            return null;
+        }
+
         return $this->batchOffset;
     }
 
     public function getBatchSize(): ?int
     {
+        if (is_bool($this->batchSize)) {
+            return null;
+        }
+
         return $this->batchSize;
     }
 
     public function getIndexName(): ?string
     {
+        if (is_bool($this->indexName)) {
+            return null;
+        }
+
         return $this->indexName;
     }
 

--- a/src/Jobs/ReindexJob.php
+++ b/src/Jobs/ReindexJob.php
@@ -101,6 +101,7 @@ class ReindexJob extends AbstractQueuedJob implements QueuedJob
 
         foreach ($classes as $class) {
             $fetcher = $this->getRegistry()->getFetcher($class);
+
             if ($fetcher) {
                 $fetchers[$class] = $fetcher;
             }
@@ -159,31 +160,55 @@ class ReindexJob extends AbstractQueuedJob implements QueuedJob
 
     public function getBatchSize(): ?int
     {
+        if (is_bool($this->batchSize)) {
+            return null;
+        }
+
         return $this->batchSize;
     }
 
     public function getFetchers(): ?array
     {
+        if (is_bool($this->fetchers)) {
+            return null;
+        }
+
         return $this->fetchers;
     }
 
     public function getFetchIndex(): ?int
     {
+        if (is_bool($this->fetchIndex)) {
+            return null;
+        }
+
         return $this->fetchIndex;
     }
 
     public function getFetchOffset(): ?int
     {
+        if (is_bool($this->fetchOffset)) {
+            return null;
+        }
+
         return $this->fetchOffset;
     }
 
     public function getOnlyClasses(): ?array
     {
+        if (is_bool($this->onlyClasses)) {
+            return null;
+        }
+
         return $this->onlyClasses;
     }
 
     public function getOnlyIndexes(): ?array
     {
+        if (is_bool($this->onlyIndexes)) {
+            return null;
+        }
+
         return $this->onlyIndexes;
     }
 

--- a/src/Jobs/RemoveDataObjectJob.php
+++ b/src/Jobs/RemoveDataObjectJob.php
@@ -76,11 +76,19 @@ class RemoveDataObjectJob extends IndexJob
 
     public function getDocument(): ?DataObjectDocument
     {
+        if (is_bool($this->document)) {
+            return null;
+        }
+
         return $this->document;
     }
 
     public function getTimestamp(): ?int
     {
+        if (is_bool($this->timestamp)) {
+            return null;
+        }
+
         return $this->timestamp;
     }
 


### PR DESCRIPTION
Apologies that I didn't find this in the PHP 8 upgrade PR, but it's very inconsistent. I can run this Job dozens of times without error, but then just every now and then it breaks.

I don't **fully** understand the issue, but this is what seems to be happening.

* A job is queued with one or more of these dynamic properties set to `null`.
* When the `jobData` is being hydrated back onto the Job, for reasons I don't understand, the value gets set to `bool` instead of `null`.
* This is causing the Job to break, since our `getters()` expect a non-boolean value.

Until we get to a point where the dynamic properties can be removed, I think it would be easier to just **not** define expected return types, so long as our code understands that possibility (which it does).