### PR TITLE
FIX Add default batch size when creating IndexJob

### DIFF
--- a/src/Jobs/IndexJob.php
+++ b/src/Jobs/IndexJob.php
@@ -6,6 +6,7 @@ use Exception;
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
+use SilverStripe\SearchService\Service\IndexConfiguration;
 use SilverStripe\SearchService\Service\Indexer;
 use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 use Symbiote\QueuedJobs\Services\QueuedJob;
@@ -34,6 +35,8 @@ class IndexJob extends AbstractQueuedJob implements QueuedJob
         ?int $batchSize = null,
         bool $processDependencies = true
     ) {
+        $batchSize = $batchSize ?: IndexConfiguration::singleton()->getBatchSize();
+
         $this->setDocuments($documents);
         $this->setMethod($method);
         $this->setBatchSize($batchSize);

--- a/tests/Jobs/IndexJobTest.php
+++ b/tests/Jobs/IndexJobTest.php
@@ -20,11 +20,12 @@ class IndexJobTest extends SearchServiceTest
         $config->set('isClassIndexed', [
             DataObjectFake::class => true,
         ]);
+        $config->set('batch_size', 6);
         $service = $this->loadIndex(20);
         $docs = $service->listDocuments('test', 100);
         $this->assertCount(20, $docs);
 
-        $job = IndexJob::create($docs, Indexer::METHOD_ADD, 6, false);
+        $job = IndexJob::create($docs, Indexer::METHOD_ADD);
         $job->setup();
         $this->assertEquals(6, $job->getBatchSize());
         $this->assertCount(20, $job->getDocuments());


### PR DESCRIPTION
Apply a similar strategy from ReindexJob where it uses the default batch size from configuration for null values.

This solves recent issue when publishing a single page does not send the document to Elastic endpoint due to `$batch_size` being null as a 3rd param of array_splice and returns an empty array as a result