### PR TITLE
v1: Fetch LIVE DataObject when checking canView()

### DIFF
--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -143,7 +143,7 @@ class DataObjectDocument implements
         $dataObject = $this->getDataObject();
 
         // If an anonymous user can't view it
-        $isPublic = Member::actAs(null, function () use ($dataObject) {
+        $isPublic = Member::actAs(null, static function () use ($dataObject) {
             // Need to make sure that the version of the DataObject that we access is always the LIVE version
             return Versioned::withVersionedMode(static function () use ($dataObject): bool {
                 Versioned::set_stage(Versioned::LIVE);

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -145,7 +145,7 @@ class DataObjectDocument implements
         // If an anonymous user can't view it
         $isPublic = Member::actAs(null, function () use ($dataObject) {
             // Need to make sure that the version of the DataObject that we access is always the LIVE version
-            return Versioned::withVersionedMode(function () use ($dataObject): bool {
+            return Versioned::withVersionedMode(static function () use ($dataObject): bool {
                 Versioned::set_stage(Versioned::LIVE);
 
                 $liveDataObject = DataObject::get($dataObject->ClassName)->byID($dataObject->ID);

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -151,6 +151,7 @@ class DataObjectDocument implements
                 $liveDataObject = DataObject::get($dataObject->ClassName)->byID($dataObject->ID);
 
                 if (!$liveDataObject || !$liveDataObject->exists()) {
+                    // Nothing to index
                     return false;
                 }
 

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -99,16 +99,22 @@ class DataObjectDocumentTest extends SearchServiceTest
 
         $childOne = $this->objFromFixture(Page::class, 'page2');
         $childTwo = $this->objFromFixture(Page::class, 'page3');
+        $childThree = $this->objFromFixture(Page::class, '  page5');
 
-        // Publish childOne
+        // Publish childOne and childThree
         $childOne->publishRecursive();
-        // Need to re-fetch childOne so that our Versioned state is up-to-date with what we just published
+        $childThree->publishRecursive();
+        // Need to re-fetch childOne and childThree so that our Versioned state is up-to-date with what we just
+        // published
         $childOne = $this->objFromFixture(Page::class, 'page2');
+        $childThree = $this->objFromFixture(Page::class, '  page5');
 
         // $docOne has a published page
         $docOne = DataObjectDocument::create($childOne);
         // $docTwo has an unpublished page
         $docTwo = DataObjectDocument::create($childTwo);
+        // $docThree has a published page
+        $docThree = DataObjectDocument::create($childThree);
 
         // Add both documents to our indexes, as this isn't the functionality we're testing here
         $config->set(
@@ -120,6 +126,9 @@ class DataObjectDocumentTest extends SearchServiceTest
                 $docTwo->getIdentifier() => [
                     'index' => 'data',
                 ],
+                $docThree->getIdentifier() => [
+                    'index' => 'data',
+                ],
             ]
         );
 
@@ -127,6 +136,8 @@ class DataObjectDocumentTest extends SearchServiceTest
         $this->assertTrue($docOne->shouldIndex());
         // Our parent page has been published, but the child has not
         $this->assertFalse($docTwo->shouldIndex());
+        // Our parent page has not been published, even though the child has
+        $this->assertFalse($docThree->shouldIndex());
 
         // Now trigger a change on our parent page (so that the draft and live versions no longer match)
         $parent->Title = 'Parent Page Changed';

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SearchService\Tests\DataObject;
 
+use Page;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\RelationList;
@@ -23,7 +24,10 @@ use SilverStripe\Versioned\Versioned;
 
 class DataObjectDocumentTest extends SearchServiceTest
 {
-    protected static $fixture_file = '../fixtures.yml';
+    protected static $fixture_file = [
+        '../fixtures.yml',
+        '../pages.yml',
+    ];
 
     protected static $extra_dataobjects = [
         VersionedDataObjectFake::class,
@@ -83,6 +87,57 @@ class DataObjectDocumentTest extends SearchServiceTest
 
         $config->set('enabled', false);
         $this->assertFalse($doc->shouldIndex());
+    }
+
+    public function testShouldIndexChild(): void
+    {
+        $config = $this->mockConfig();
+
+        $parent = $this->objFromFixture(Page::class, 'page1');
+        // Make sure our Parent is published before we fetch our child pages
+        $parent->publishRecursive();
+
+        $childOne = $this->objFromFixture(Page::class, 'page2');
+        $childTwo = $this->objFromFixture(Page::class, 'page3');
+
+        // Publish childOne
+        $childOne->publishRecursive();
+        // Need to re-fetch childOne so that our Versioned state is up-to-date with what we just published
+        $childOne = $this->objFromFixture(Page::class, 'page2');
+
+        // $docOne has a published page
+        $docOne = DataObjectDocument::create($childOne);
+        // $docTwo has an unpublished page
+        $docTwo = DataObjectDocument::create($childTwo);
+
+        // Add both documents to our indexes, as this isn't the functionality we're testing here
+        $config->set(
+            'getIndexesForDocument',
+            [
+                $docOne->getIdentifier() => [
+                    'index' => 'data',
+                ],
+                $docTwo->getIdentifier() => [
+                    'index' => 'data',
+                ],
+            ]
+        );
+
+        // Our parent page has been published, and so has our child page, so this should be indexable
+        $this->assertTrue($docOne->shouldIndex());
+        // Our parent page has been published, but the child has not
+        $this->assertFalse($docTwo->shouldIndex());
+
+        // Now trigger a change on our parent page (so that the draft and live versions no longer match)
+        $parent->Title = 'Parent Page Changed';
+        $parent->write();
+
+        // Need to re-fetch childOne so that we re-fetch the Parent when we request canView()
+        $childOne = $this->objFromFixture(Page::class, 'page2');
+        // Recreate the Document with our new child page
+        $docOne = DataObjectDocument::create($childOne);
+        // Check that our child page is still indexable, even after our parent page was given a different draft version
+        $this->assertTrue($docOne->shouldIndex());
     }
 
     public function testMarkIndexed(): void

--- a/tests/pages.yml
+++ b/tests/pages.yml
@@ -1,6 +1,6 @@
 Page:
   page1:
-    Title: Parent Page
+    Title: Parent Page 1
     ShowInSearch: 1
   page2:
     Title: Child Page 1
@@ -9,4 +9,11 @@ Page:
   page3:
     Title: Child Page 2
     Parent: =>Page.page1
+    ShowInSearch: 1
+  page4:
+    Title: Parent Page 2
+    ShowInSearch: 1
+  page5:
+    Title: Child Page 3
+    Parent: =>Page.page4
     ShowInSearch: 1

--- a/tests/pages.yml
+++ b/tests/pages.yml
@@ -1,0 +1,12 @@
+Page:
+  page1:
+    Title: Parent Page
+    ShowInSearch: 1
+  page2:
+    Title: Child Page 1
+    Parent: =>Page.page1
+    ShowInSearch: 1
+  page3:
+    Title: Child Page 2
+    Parent: =>Page.page1
+    ShowInSearch: 1


### PR DESCRIPTION
Fixes #61
Relates to #78

Whenever we attempt to check if a user `canView()` we need to make sure that our reading mode (and query mode) is LIVE.