### PR TITLE
v2: Fetch LIVE DataObject when checking canView()

### DIFF
--- a/tests/pages.yml
+++ b/tests/pages.yml
@@ -1,0 +1,19 @@
+Page:
+  page1:
+    Title: Parent Page
+    ShowInSearch: 1
+  page2:
+    Title: Child Page 1
+    Parent: =>Page.page1
+    ShowInSearch: 1
+  page3:
+    Title: Child Page 2
+    Parent: =>Page.page1
+    ShowInSearch: 1
+  page4:
+    Title: Parent Page 2
+    ShowInSearch: 1
+  page5:
+    Title: Child Page 3
+    Parent: =>Page.page4
+    ShowInSearch: 1


### PR DESCRIPTION
Fixes #61
Relates to #77 

Whenever we attempt to check if a user canView() we need to make sure that our reading mode (and query mode) is LIVE.