### PR TITLE
Update subsite check to ensure the DO has the field

### DIFF
--- a/src/Extensions/Subsites/IndexConfigurationExtension.php
+++ b/src/Extensions/Subsites/IndexConfigurationExtension.php
@@ -16,12 +16,11 @@ class IndexConfigurationExtension extends Extension
             return;
         }
 
-        $docSubsiteId = $doc->getDataObject()->SubsiteID ?? 0;
-
-        if ((int) $docSubsiteId === 0) {
+        // Which whether the data object has the SubsiteID
+        if (!$doc->getDataObject()->hasField('SubsiteID')) {
             $this->updateDocumentWithoutSubsite($doc, $indexes);
         } else {
-            $this->updateDocumentWithSubsite($indexes, $docSubsiteId);
+            $this->updateDocumentWithSubsite($indexes, (int)$doc->getDataObject()->SubsiteID);
         }
     }
 


### PR DESCRIPTION
Instead of checking for the value of the SubsiteID, we are checking if the SubsiteID field exists in the object. We want to check if the DataObject implements the subsite functionality or not.

Objects that do not implement subsite and objects such as SiteTree that implement the subsite have the same value `0` when the SiteTree is created for the Main Site.
