### PR TITLE
Bugfix: Remove GridFieldFilterHeader from ModelAdmin GridField

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -144,6 +144,10 @@
         <exclude name="SlevomatCodingStandard.Complexity.Cognitive.ComplexityTooHigh"/>
         <!-- Don't require exit early -->
         <exclude name="SlevomatCodingStandard.ControlStructures.EarlyExit.EarlyExitNotUsed"/>
+        <!-- Don't require keys to be sorted alphabetically -->
+        <exclude name="SlevomatCodingStandard.Arrays.AlphabeticallySortedByKeys.IncorrectKeyOrder"/>
+        <!-- Don't deny self references -->
+        <exclude name="SlevomatCodingStandard.Classes.RequireSelfReference.RequiredSelfReference"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses">

--- a/src/Admin/SearchAdmin.php
+++ b/src/Admin/SearchAdmin.php
@@ -9,6 +9,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldFilterHeader;
 use SilverStripe\Forms\GridField\GridFieldPaginator;
 use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\LiteralField;
@@ -110,10 +111,12 @@ class SearchAdmin extends LeftAndMain implements PermissionProvider
         } else {
             // Indexed documents field
             $indexDocumentsField = GridField::create('IndexedDocuments', 'Documents by Index', $indexedDocumentsList);
-            $indexDocumentsField->getConfig()->getComponentByType(GridFieldPaginator::class)->setItemsPerPage(5);
+            $indexDocumentsFieldConfig = $indexDocumentsField->getConfig();
+            $indexDocumentsFieldConfig->removeComponentsByType(GridFieldFilterHeader::class);
+            $indexDocumentsFieldConfig->getComponentByType(GridFieldPaginator::class)->setItemsPerPage(5);
 
             if ($canReindex) {
-                $indexDocumentsField->getConfig()->addComponent(new SearchReindexFormAction());
+                $indexDocumentsFieldConfig->addComponent(new SearchReindexFormAction());
             }
 
             $fields[] = $indexDocumentsField;

--- a/src/Jobs/ReindexJob.php
+++ b/src/Jobs/ReindexJob.php
@@ -84,9 +84,9 @@ class ReindexJob extends AbstractQueuedJob implements QueuedJob
             $this->getConfiguration()->setOnlyIndexes($this->getOnlyIndexes());
         }
 
-        $classes = $this->getOnlyClasses() && count($this->getOnlyClasses()) ?
-            $this->getOnlyClasses() :
-            $this->getConfiguration()->getSearchableBaseClasses();
+        $classes = $this->getOnlyClasses() && count($this->getOnlyClasses())
+            ? $this->getOnlyClasses()
+            : $this->getConfiguration()->getSearchableBaseClasses();
 
         /** @var DocumentFetcherInterface[] $fetchers */
         $fetchers = [];


### PR DESCRIPTION
- Relates to changes made in Framework 4.13

Fixes #82
Closes #82
Relates to https://github.com/silverstripe/silverstripe-framework/issues/10768

I do not believe there is any fundamental change here. Previously our `GridFieldFilterHeader` was just invisibly doing [nothing], now we are required to explicitly remove it if we don't want to use its functionality.