### PR TITLE
FIX Unpublising parent pages should include child pages

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -26,4 +26,5 @@ Only:
 ---
 SilverStripe\CMS\Model\SiteTree:
   extensions:
-    - SilverStripe\SearchService\Extensions\SearchServiceExtension
+    SearchServiceExtension: SilverStripe\SearchService\Extensions\SearchServiceExtension
+    SiteTreeHierarchyExtension: SilverStripe\SearchService\Extensions\SiteTreeHierarchyExtension

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,17 @@
-<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
-    <testsuite name="Default">
-        <directory>tests/</directory>
-    </testsuite>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">tests/</directory>
+    </exclude>
+  </coverage>
+  <testsuite name="Default">
+    <directory>tests/</directory>
+  </testsuite>
+  <php>
+    <get name="flush" value="1"/>
+  </php>
 </phpunit>

--- a/src/DataObject/DataObjectBatchProcessor.php
+++ b/src/DataObject/DataObjectBatchProcessor.php
@@ -31,6 +31,8 @@ class DataObjectBatchProcessor extends BatchProcessor
         $this->run($job);
 
         foreach ($documents as $doc) {
+            // Indexer::METHOD_ADD as default parameter make sure we check first its related documents
+            // and decide whether we should delete or update them automatically.
             $childJob = RemoveDataObjectJob::create($doc, $timestamp);
             $this->run($childJob);
         }

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -372,10 +372,12 @@ class DataObjectDocument implements
     }
 
     /**
-     * Collects related documents based on the underlying relationship of their DataObjects.
-     * These data are typically joined by $has_many or $many_many configured on searcheable classes
-     * defined by their fields to be indexed. Other relationships are considered a rare case.
+     * Collects documents that depend on the current DataObject for indexing.
+     * It will inspect the search index configuration for anything using this object in a field or, if the
+     * current object is an instance of SiteTree, it will respect `enforce_strict_hierarchy`
+     * and add any child objects.
      *
+     * @see [the dependency tracking docs](docs/en/usage.md#dependency-tracking)
      * @return DocumentInterface[]
      */
     public function getDependentDocuments(): array

--- a/src/DataObject/DataObjectDocument.php
+++ b/src/DataObject/DataObjectDocument.php
@@ -372,6 +372,10 @@ class DataObjectDocument implements
     }
 
     /**
+     * Collects related documents based on the underlying relationship of their DataObjects.
+     * These data are typically joined by $has_many or $many_many configured on searcheable classes
+     * defined by their fields to be indexed. Other relationships are considered a rare case.
+     *
      * @return DocumentInterface[]
      */
     public function getDependentDocuments(): array

--- a/src/Extensions/SiteTreeHierarchyExtension.php
+++ b/src/Extensions/SiteTreeHierarchyExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\SearchService\Extensions;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Extension;
+use SilverStripe\SearchService\DataObject\DataObjectDocument;
+
+class SiteTreeHierarchyExtension extends Extension
+{
+
+    public function updateSearchDependentDocuments(array &$dependentDocs): void
+    {
+        if (!SiteTree::config()->get('enforce_strict_hierarchy')) {
+            return;
+        }
+
+        $page = $this->getOwner();
+
+        foreach ($page->AllChildren() as $record) {
+            $document = DataObjectDocument::create($record);
+            $dependentDocs[$document->getIdentifier()] = $document;
+            $dependentDocs = array_merge($dependentDocs, $document->getDependentDocuments());
+        }
+    }
+
+}

--- a/src/Jobs/RemoveDataObjectJob.php
+++ b/src/Jobs/RemoveDataObjectJob.php
@@ -11,6 +11,10 @@ use SilverStripe\SearchService\Service\Indexer;
 use SilverStripe\Versioned\Versioned;
 
 /**
+ *  By virture of the default parameter, Index::METHOD_ADD, this does not remove the documents straight away.
+ *  It checks first the status of the underlaying DataObjects and decides whether to remove or add them to the index.
+ *  Then pass on to the parent's process() method to handle the job.
+ *
  * @property DataObjectDocument|null $document
  * @property int|null $timestamp
  */
@@ -19,6 +23,8 @@ class RemoveDataObjectJob extends IndexJob
 
     public function __construct(?DataObjectDocument $document = null, ?int $timestamp = null, ?int $batchSize = null)
     {
+        // Indexer::METHOD_ADD as default parameter make sure we check first its related documents
+        // whether we should delete or update them automatically.
         parent::__construct([], Indexer::METHOD_ADD, $batchSize);
 
         if ($document !== null) {
@@ -46,7 +52,7 @@ class RemoveDataObjectJob extends IndexJob
      */
     public function setup(): void
     {
-        // Set the documents in setup to ensure async
+        /** @var DBDatetime $datetime - set the documents in setup to ensure async */
         $datetime = DBField::create_field('Datetime', $this->getTimestamp());
         $archiveDate = $datetime->format($datetime->getISOFormat());
         $documents = Versioned::withVersionedMode(function () use ($archiveDate) {

--- a/src/Jobs/RemoveDataObjectJob.php
+++ b/src/Jobs/RemoveDataObjectJob.php
@@ -82,11 +82,8 @@ class RemoveDataObjectJob extends IndexJob
                     // Taking into account that this queued job has a reference of existing child pages
                     // We need to make sure that we are able to send these pages to ElasticSearch etc. for removal
                     $oldRecord = $doc->getDataObject();
-
-                    if ($oldRecord->isArchived() || $oldRecord->isOnDraft()) {
-                        $document = DataObjectDocument::create($oldRecord);
-                        $carry[$document->getIdentifier()] = $document;
-                    }
+                    $document = DataObjectDocument::create($oldRecord);
+                    $carry[$document->getIdentifier()] = $document;
 
                     return $carry;
                 },

--- a/src/Jobs/RemoveDataObjectJob.php
+++ b/src/Jobs/RemoveDataObjectJob.php
@@ -52,20 +52,40 @@ class RemoveDataObjectJob extends IndexJob
         $documents = Versioned::withVersionedMode(function () use ($archiveDate) {
             Versioned::reading_archived_date($archiveDate);
 
+            $currentDocument = $this->getDocument();
             // Go back in time to find out what the owners were before unpublish
-            $dependentDocs = $this->document->getDependentDocuments();
+            $dependentDocs = $currentDocument->getDependentDocuments();
 
             // refetch everything on the live stage
             Versioned::set_stage(Versioned::LIVE);
 
-            return array_map(function (DataObjectDocument $doc) {
-                return DataObjectDocument::create(
-                    DataObject::get_by_id(
-                        $doc->getSourceClass(),
-                        $doc->getDataObject()->ID
-                    )
-                );
-            }, $dependentDocs);
+            return array_reduce(
+                $dependentDocs,
+                function (array $carry, DataObjectDocument $doc) {
+                    $record = DataObject::get_by_id($doc->getSourceClass(), $doc->getDataObject()->ID);
+
+                    // Since SiteTree::onBeforeDelete recursively deletes the child pages,
+                    // they end up not found on a live environment which breaks DataObjectDocument::_constructor
+                    if ($record) {
+                        $document = DataObjectDocument::create($record);
+                        $carry[$document->getIdentifier()] = $document;
+
+                        return $carry;
+                    }
+
+                    // Taking into account that this queued job has a reference of existing child pages
+                    // We need to make sure that we are able to send these pages to ElasticSearch etc. for removal
+                    $oldRecord = $doc->getDataObject();
+
+                    if ($oldRecord->isArchived() || $oldRecord->isOnDraft()) {
+                        $document = DataObjectDocument::create($oldRecord);
+                        $carry[$document->getIdentifier()] = $document;
+                    }
+
+                    return $carry;
+                },
+                []
+            );
         });
 
         $this->setDocuments($documents);

--- a/src/Service/Indexer.php
+++ b/src/Service/Indexer.php
@@ -124,6 +124,8 @@ class Indexer
                 );
 
                 if ($dependentDocs) {
+                    // Indexer::METHOD_ADD as default parameter make sure we check first its related documents
+                    // and decide whether we should delete or update them automatically.
                     $child = Indexer::create($dependentDocs, self::METHOD_ADD, $this->getBatchSize());
 
                     while (!$child->finished()) {

--- a/src/Service/Indexer.php
+++ b/src/Service/Indexer.php
@@ -5,6 +5,7 @@ namespace SilverStripe\SearchService\Service;
 use InvalidArgumentException;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\SearchService\Interfaces\DependencyTracker;
 use SilverStripe\SearchService\Interfaces\DocumentAddHandler;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
@@ -12,6 +13,7 @@ use SilverStripe\SearchService\Interfaces\DocumentRemoveHandler;
 use SilverStripe\SearchService\Interfaces\IndexingInterface;
 use SilverStripe\SearchService\Service\Traits\ConfigurationAware;
 use SilverStripe\SearchService\Service\Traits\ServiceAware;
+use SilverStripe\Versioned\Versioned;
 
 class Indexer
 {
@@ -76,6 +78,19 @@ class Indexer
                     if ($document instanceof DocumentAddHandler) {
                         $document->onAddToSearchIndexes(DocumentAddHandler::BEFORE_ADD);
                     }
+
+                    // Making sure we get the Live version of the DataObject before indexing the document
+                    Versioned::withVersionedMode(static function () use ($document): void {
+                        Versioned::set_stage(Versioned::LIVE);
+                        $dataObject = $document->getDataObject();
+
+                        if (!$dataObject) {
+                            return;
+                        }
+
+                        $liveDataObject = DataObject::get($dataObject->ClassName)->byID($dataObject->ID);
+                        $document->setDataObject($liveDataObject);
+                    });
 
                     $toUpdate[] = $document;
                 } else {

--- a/src/Service/Indexer.php
+++ b/src/Service/Indexer.php
@@ -5,8 +5,6 @@ namespace SilverStripe\SearchService\Service;
 use InvalidArgumentException;
 use SilverStripe\Core\Config\Configurable;
 use SilverStripe\Core\Injector\Injectable;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\SearchService\Interfaces\DataObjectDocumentInterface;
 use SilverStripe\SearchService\Interfaces\DependencyTracker;
 use SilverStripe\SearchService\Interfaces\DocumentAddHandler;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
@@ -14,7 +12,6 @@ use SilverStripe\SearchService\Interfaces\DocumentRemoveHandler;
 use SilverStripe\SearchService\Interfaces\IndexingInterface;
 use SilverStripe\SearchService\Service\Traits\ConfigurationAware;
 use SilverStripe\SearchService\Service\Traits\ServiceAware;
-use SilverStripe\Versioned\Versioned;
 
 class Indexer
 {
@@ -78,16 +75,6 @@ class Indexer
                 if ($document->shouldIndex()) {
                     if ($document instanceof DocumentAddHandler) {
                         $document->onAddToSearchIndexes(DocumentAddHandler::BEFORE_ADD);
-                    }
-
-                    if ($document instanceof DataObjectDocumentInterface) {
-                        // Making sure we get the Live version of the DataObject before indexing the document
-                        Versioned::withVersionedMode(static function () use ($document): void {
-                            Versioned::set_stage(Versioned::LIVE);
-                            $dataObject = $document->getDataObject();
-                            $liveDataObject = DataObject::get($dataObject->ClassName)->byID($dataObject->ID);
-                            $document->setDataObject($liveDataObject);
-                        });
                     }
 
                     $toUpdate[] = $document;

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\SearchService\Tests\DataObject;
 
 use Page;
-use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\RelationList;
@@ -660,4 +659,5 @@ class DataObjectDocumentTest extends SearchServiceTest
 
         unserialize(serialize($doc));
     }
+
 }

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -647,7 +647,7 @@ class DataObjectDocumentTest extends SearchServiceTest
         $id = $dataObject->ID;
 
         $doc = DataObjectDocument::create($dataObject)->setShouldFallbackToLatestVersion(true);
-        $dataObject->delete();
+        $dataObject->doArchive();
 
         /** @var DataObjectDocument $serialDoc */
         $serialDoc = unserialize(serialize($doc));
@@ -660,29 +660,4 @@ class DataObjectDocumentTest extends SearchServiceTest
 
         unserialize(serialize($doc));
     }
-
-    public function testGetChildDocuments(): void
-    {
-        $pageOne = $this->objFromFixture(Page::class, 'page1');
-        $pageTwo = $this->objFromFixture(Page::class, 'page2');
-        $pageThree = $this->objFromFixture(Page::class, 'page3');
-        $pageSeven = $this->objFromFixture(Page::class, 'page7');
-        $pageEight = $this->objFromFixture(Page::class, 'page8');
-
-        $parentDocument = DataObjectDocument::create($pageOne);
-        $identifierPrefix = preg_replace('/\d$/', '', $parentDocument->getIdentifier());
-        $childDocs = $parentDocument->getChildDocuments($pageOne);
-
-        $expectedIdentifiers = [
-            $identifierPrefix . $pageTwo->ID,
-            $identifierPrefix . $pageThree->ID,
-            $identifierPrefix . $pageSeven->ID,
-            $identifierPrefix . $pageEight->ID,
-        ];
-
-        $resultIdentifiers = ArrayList::create($childDocs)->column('getIdentifier');
-
-        $this->assertEqualsCanonicalizing($expectedIdentifiers, $resultIdentifiers);
-    }
-
 }

--- a/tests/DataObject/DataObjectDocumentTest.php
+++ b/tests/DataObject/DataObjectDocumentTest.php
@@ -17,6 +17,7 @@ use SilverStripe\SearchService\Tests\Fake\DataObjectFakePrivate;
 use SilverStripe\SearchService\Tests\Fake\DataObjectFakeVersioned;
 use SilverStripe\SearchService\Tests\Fake\DataObjectSubclassFake;
 use SilverStripe\SearchService\Tests\Fake\ImageFake;
+use SilverStripe\SearchService\Tests\Fake\PageFake;
 use SilverStripe\SearchService\Tests\Fake\TagFake;
 use SilverStripe\SearchService\Tests\SearchServiceTest;
 use SilverStripe\Security\Member;
@@ -45,6 +46,7 @@ class DataObjectDocumentTest extends SearchServiceTest
         DataObjectSubclassFake::class,
         DataObjectFakeVersioned::class,
         DataObjectFakePrivate::class,
+        PageFake::class,
     ];
 
     public function testGetIdentifier(): void

--- a/tests/Extensions/SiteTreeHierarchyExtensionTest.php
+++ b/tests/Extensions/SiteTreeHierarchyExtensionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SilverStripe\SearchService\Tests\Extensions;
+
+use Page;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\SearchService\DataObject\DataObjectDocument;
+use SilverStripe\SearchService\Extensions\SiteTreeHierarchyExtension;
+
+class SiteTreeHierarchyExtensionTest extends SapphireTest
+{
+
+    protected static $fixture_file = [ // phpcs:ignore
+        '../fixtures.yml',
+        '../pages.yml',
+    ];
+
+    public function testGetChildDocuments(): void
+    {
+        $pageOne = $this->objFromFixture(Page::class, 'page1');
+        $pageTwo = $this->objFromFixture(Page::class, 'page2');
+        $pageThree = $this->objFromFixture(Page::class, 'page3');
+        $pageSeven = $this->objFromFixture(Page::class, 'page7');
+        $pageEight = $this->objFromFixture(Page::class, 'page8');
+
+        $extension = new SiteTreeHierarchyExtension();
+        $extension->setOwner($pageOne);
+
+        $parentDocument = DataObjectDocument::create($pageOne);
+        $identifierPrefix = preg_replace('/\d+$/', '', $parentDocument->getIdentifier());
+        $childDocs = [];
+        $extension->updateSearchDependentDocuments($childDocs);
+
+        $expectedIdentifiers = [
+            $identifierPrefix . $pageTwo->ID,
+            $identifierPrefix . $pageThree->ID,
+            $identifierPrefix . $pageSeven->ID,
+            $identifierPrefix . $pageEight->ID,
+        ];
+
+        $resultIdentifiers = ArrayList::create($childDocs)->column('getIdentifier');
+
+        $this->assertEqualsCanonicalizing($expectedIdentifiers, $resultIdentifiers);
+    }
+
+}

--- a/tests/Fake/DocumentFake.php
+++ b/tests/Fake/DocumentFake.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\SearchService\Tests\Fake;
 
+use SilverStripe\ORM\DataObject;
 use SilverStripe\SearchService\Interfaces\DependencyTracker;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
 
@@ -53,6 +54,11 @@ class DocumentFake implements DocumentInterface, DependencyTracker
     public function getDependentDocuments(): array
     {
         return $this->dependentDocuments;
+    }
+
+    public function getDataObject(): ?DataObject
+    {
+        return null;
     }
 
 }

--- a/tests/Fake/DocumentFake.php
+++ b/tests/Fake/DocumentFake.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\SearchService\Tests\Fake;
 
-use SilverStripe\ORM\DataObject;
 use SilverStripe\SearchService\Interfaces\DependencyTracker;
 use SilverStripe\SearchService\Interfaces\DocumentInterface;
 
@@ -54,11 +53,6 @@ class DocumentFake implements DocumentInterface, DependencyTracker
     public function getDependentDocuments(): array
     {
         return $this->dependentDocuments;
-    }
-
-    public function getDataObject(): ?DataObject
-    {
-        return null;
     }
 
 }

--- a/tests/Fake/ImageFake.php
+++ b/tests/Fake/ImageFake.php
@@ -10,11 +10,13 @@ class ImageFake extends DataObject implements TestOnly
 {
 
     private static array $db = [
+        'Title' => 'Varchar',
         'URL' => 'Varchar',
     ];
 
     private static array $has_one = [
         'Parent' => DataObjectFake::class,
+        'PageFake' => PageFake::class,
     ];
 
     private static array $many_many = [
@@ -26,5 +28,11 @@ class ImageFake extends DataObject implements TestOnly
     ];
 
     private static string $table_name = 'ImageFake';
+
+    // For DataObjects that are not versioned, canView is needed and must return true
+    public function canView($member = null) // phpcs:ignore SlevomatCodingStandard.TypeHints
+    {
+        return true;
+    }
 
 }

--- a/tests/Fake/PageFake.php
+++ b/tests/Fake/PageFake.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\SearchService\Tests\Fake;
+
+use Page;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\SearchService\Extensions\SearchServiceExtension;
+
+class PageFake extends Page implements TestOnly
+{
+
+    private static array $many_many = [
+        'Tags' => TagFake::class,
+    ];
+
+    private static array $has_many = [
+        'Images' => ImageFake::class,
+    ];
+
+    private static array $owns = [
+        'Tags',
+        'Images',
+    ];
+
+    private static string $table_name = 'PageFake';
+
+    private static array $extensions = [
+        SearchServiceExtension::class,
+    ];
+
+}

--- a/tests/Jobs/RemoveDataObjectJobTest.php
+++ b/tests/Jobs/RemoveDataObjectJobTest.php
@@ -17,7 +17,7 @@ use SilverStripe\Security\Member;
 class RemoveDataObjectJobTest extends SearchServiceTest
 {
 
-    protected static $fixture_file = '../fixtures.yml'; // @phpcs:ignore
+    protected static $fixture_file = '../fixtures.yml'; // phpcs:ignore
 
     /**
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint

--- a/tests/Jobs/RemoveRelatedDataObjectJobTest.php
+++ b/tests/Jobs/RemoveRelatedDataObjectJobTest.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace SilverStripe\SearchService\Tests\Jobs;
+
+use Page;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\SearchService\DataObject\DataObjectDocument;
+use SilverStripe\SearchService\Jobs\RemoveDataObjectJob;
+use SilverStripe\SearchService\Schema\Field;
+use SilverStripe\SearchService\Service\Indexer;
+use SilverStripe\SearchService\Tests\Fake\DataObjectFake;
+use SilverStripe\SearchService\Tests\Fake\DataObjectFakePrivate;
+use SilverStripe\SearchService\Tests\Fake\DataObjectFakeVersioned;
+use SilverStripe\SearchService\Tests\Fake\ImageFake;
+use SilverStripe\SearchService\Tests\Fake\PageFake;
+use SilverStripe\SearchService\Tests\Fake\TagFake;
+use SilverStripe\SearchService\Tests\SearchServiceTest;
+use SilverStripe\Security\Member;
+use SilverStripe\Versioned\Versioned;
+
+class RemoveRelatedDataObjectJobTest extends SearchServiceTest
+{
+
+    protected static $fixture_file = [ // @phpcs:ignore
+        '../fixtures.yml',
+        '../pages.yml',
+    ];
+
+    /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+     * @var array
+     */
+    protected static $extra_dataobjects = [
+        DataObjectFake::class,
+        DataObjectFakePrivate::class,
+        DataObjectFakeVersioned::class,
+        TagFake::class,
+        ImageFake::class,
+        Member::class,
+        PageFake::class,
+    ];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Publish all pages in fixtures since the internal dependency checks looks for live version
+        for ($i = 1; $i <= 8; $i++) {
+            $this->objFromFixture(Page::class, 'page' . $i)->publishRecursive();
+        }
+
+        $this->objFromFixture(PageFake::class, 'page9')->publishRecursive();
+        $this->objFromFixture(PageFake::class, 'page10')->publishRecursive();
+        $this->objFromFixture(PageFake::class, 'page11')->publishRecursive();
+        $this->objFromFixture(TagFake::class, 'four')->publishRecursive();
+        $this->objFromFixture(TagFake::class, 'five')->publishRecursive();
+        $this->objFromFixture(TagFake::class, 'six')->publishRecursive();
+
+        $config = $this->mockConfig();
+
+        $config->set(
+            'getSearchableClasses',
+            [
+                DataObjectFake::class,
+                TagFake::class,
+                ImageFake::class,
+                PageFake::class,
+                Page::class,
+            ]
+        );
+
+        $config->set(
+            'getFieldsForClass',
+            [
+                DataObjectFake::class => [
+                    new Field('title'),
+                    new Field('tagtitles', 'Tags.Title'),
+                ],
+                PageFake::class => [
+                    new Field('title'),
+                    new Field('tagtitles', 'Tags.Title'),
+                    new Field('images', 'Images.URL'),
+                ],
+                ImageFake::class => [
+                    new Field('title'),
+                    new Field('url'),
+                    new Field('tagtitles', 'Tags.Title'),
+                ],
+            ]
+        );
+
+        $index = [
+            'main' => [
+                'includeClasses' => [
+                    DataObjectFake::class => ['title' => true],
+                    TagFake::class => ['title' => true],
+                    ImageFake::class => ['title' => true],
+                    PageFake::class => ['title' => true],
+                    Page::class => ['title' => true],
+                ],
+            ],
+        ];
+
+        $config->set(
+            'getIndexesForClassName',
+            [
+                DataObjectFake::class => $index,
+                TagFake::class => $index,
+                ImageFake::class => $index,
+                PageFake::class => $index,
+                Page::class => $index,
+            ]
+        );
+    }
+
+    public function testUnpublishParentPage(): void
+    {
+        $childA = $this->objFromFixture(Page::class, 'page2');
+        $childB = $this->objFromFixture(Page::class, 'page3');
+        $grandChildA1 = $this->objFromFixture(Page::class, 'page7');
+        $grandChildA2 = $this->objFromFixture(Page::class, 'page8');
+
+        $this->assertTrue($childA->isPublished());
+        $this->assertTrue($childB->isPublished());
+        $this->assertTrue($grandChildA1->isPublished());
+        $this->assertTrue($grandChildA2->isPublished());
+
+        $pageOne = $this->objFromFixture(Page::class, 'page1');
+        $pageOne->doUnpublish();
+
+        // Default behaviour when unpublishng the parent page
+        $this->assertTrue(SiteTree::config()->get('enforce_strict_hierarchy'));
+        $this->assertFalse($childA->isPublished());
+        $this->assertFalse($childB->isPublished());
+        $this->assertFalse($grandChildA1->isPublished());
+        $this->assertFalse($grandChildA2->isPublished());
+
+        // Queue up a job to remove a page with child pages are added as related documents
+        $pageDoc = DataObjectDocument::create($pageOne);
+        $job = RemoveDataObjectJob::create($pageDoc);
+        $job->setup();
+
+        // Creating this job does not necessarily mean to delete documents from index
+        $this->assertEquals(Indexer::METHOD_ADD, $job->getMethod());
+
+        // Grab what Documents the Job determined it needed to action
+        /** @var DataObjectDocument[] $documents */
+        $documents = $job->getDocuments();
+
+        // There should be two Pages with this Tag assigned
+        $this->assertCount(4, $documents);
+
+        $expectedTitles = [
+            'Child of Parent Page 1 - A',
+            'Child of Parent Page 1 - B',
+            'Grandchild of Parent Page 1 - A1',
+            'Grandchild of Parent Page 1 - A2',
+        ];
+
+        $resultTitles = [];
+
+        // This determines whether the document should be added or removed from from the index
+        foreach ($documents as $document) {
+            $resultTitles[] = $document->getDataObject()?->Title;
+
+            // The document should be removed from index
+            $this->assertFalse($document->shouldIndex());
+        }
+
+        $this->assertEqualsCanonicalizing($expectedTitles, $resultTitles);
+    }
+
+    public function testUnpublishRelatedTagsObject(): void
+    {
+        $tagFour = $this->objFromFixture(TagFake::class, 'four');
+        $tagFour->doUnpublish();
+
+        // Queue up a job to remove our Tag, the result should be that any related DataObject (DOs that have this Tag
+        // assigned to them) are added as related Documents
+        $job = RemoveDataObjectJob::create(
+            DataObjectDocument::create($tagFour)
+        );
+        $job->setup();
+
+        // Creating this job does not necessarily mean to delete documents from index
+        $this->assertEquals(Indexer::METHOD_ADD, $job->getMethod());
+
+        // Grab what Documents the Job determined it needed to action
+        /** @var DataObjectDocument[] $documents */
+        $documents = $job->getDocuments();
+
+        // There should be two Pages with this Tag assigned
+        $this->assertCount(3, $documents);
+
+        $expectedTitles = [
+            'Child of Parent Page 2 - B',
+            'Great Grandchild of Parent Page 2 - B1 - One',
+            'Image Fake Three',
+        ];
+
+        $pageChild = $this->objFromFixture(PageFake::class, 'page9');
+        $grandChild = $this->objFromFixture(PageFake::class, 'page10');
+        $greatGrandChild = $this->objFromFixture(PageFake::class, 'page11');
+        $imageThree = $this->objFromFixture(ImageFake::class, 'three');
+        $imageFour = $this->objFromFixture(ImageFake::class, 'four');
+
+        $resultTitles = [];
+
+        // This determines whether the document should be added or removed from from the index
+        foreach ($documents as $document) {
+            $resultTitles[] = $document->getDataObject()?->Title;
+
+            // The document should be added to index
+            $this->assertTrue($document->shouldIndex());
+        }
+
+        $this->assertEqualsCanonicalizing(
+            $expectedTitles,
+            $resultTitles
+        );
+
+        $this->assertEqualsCanonicalizing(
+            $expectedTitles,
+            [
+                $pageChild->Title,
+                $greatGrandChild->Title,
+                $imageThree->Title,
+            ],
+        );
+
+        Versioned::withVersionedMode(function () use (
+            $tagFour,
+            $pageChild,
+            $greatGrandChild
+        ): void {
+            Versioned::set_stage(Versioned::LIVE);
+
+            $this->assertNotContains($tagFour->ID, $pageChild->Tags()->column('ID'));
+            $this->assertNotContains($tagFour->ID, $greatGrandChild->Tags()->column('ID'));
+        });
+
+
+        $tagFive = $this->objFromFixture(TagFake::class, 'five');
+        $tagFive->doUnpublish();
+        // Queue up a job to remove our Tag, the result should be that any related DataObject (DOs that have this Tag
+        // assigned to them) are added as related Documents
+        $job2 = RemoveDataObjectJob::create(
+            DataObjectDocument::create($tagFive)
+        );
+        $job2->setup();
+
+        // Creating this job does not necessarily mean to delete documents from index
+        $this->assertEquals(Indexer::METHOD_ADD, $job->getMethod());
+
+        // Grab what Documents the Job determined it needed to action
+        /** @var DataObjectDocument[] $documents */
+        $documents = $job2->getDocuments();
+
+        $resultTitles = [];
+
+        foreach ($documents as $document) {
+            $resultTitles[] = $document->getDataObject()?->Title;
+
+            // The document should be added to index
+            $this->assertTrue($document->shouldIndex());
+        }
+
+        // There should be two Pages with this Tag assigned
+        $this->assertCount(4, $documents);
+
+        $expectedTitles = [
+            'Child of Parent Page 2 - B',
+            'Grandchild of Parent Page 2 - B1',
+            'Image Fake Three',
+            'Image Fake Four',
+        ];
+
+        $this->assertEqualsCanonicalizing($expectedTitles, $resultTitles);
+        $this->assertEqualsCanonicalizing(
+            $expectedTitles,
+            [
+                $pageChild->Title,
+                $grandChild->Title,
+                $imageThree->Title,
+                $imageFour->Title,
+            ],
+        );
+
+        Versioned::withVersionedMode(function () use (
+            $tagFive,
+            $pageChild,
+            $grandChild,
+            $imageThree,
+            $imageFour,
+        ): void {
+            Versioned::set_stage(Versioned::LIVE);
+
+            $this->assertNotContains($tagFive->ID, $pageChild->Tags()->column('ID'));
+            $this->assertNotContains($tagFive->ID, $grandChild->Tags()->column('ID'));
+            $this->assertNotContains($tagFive->ID, $imageThree->Tags()->column('ID'));
+            $this->assertNotContains($tagFive->ID, $imageFour->Tags()->column('ID'));
+        });
+
+        // Then unpublish these related pages to include them to the documents to be removed
+        $pageChild->doUnpublish();
+        $grandChild->doUnpublish();
+        $imageThree->delete();
+        $imageFour->delete();
+
+        /** @var DataObjectDocument[] $documents */
+        $documents = $job2->getDocuments();
+        $resultTitles = [];
+
+        foreach ($documents as $document) {
+            $resultTitles[] = $document->getDataObject()?->Title;
+
+            // The document should be removed from index
+            $this->assertFalse($document->shouldIndex());
+        }
+
+        // There should be two Pages with this Tag assigned
+        $this->assertCount(4, $documents);
+
+        $expectedTitles = [
+            'Child of Parent Page 2 - B',
+            'Grandchild of Parent Page 2 - B1',
+            'Image Fake Three',
+            'Image Fake Four',
+        ];
+
+        $this->assertEqualsCanonicalizing($expectedTitles, $resultTitles);
+        $this->assertEqualsCanonicalizing(
+            $expectedTitles,
+            [
+                $pageChild->Title,
+                $grandChild->Title,
+                $imageThree->Title,
+                $imageFour->Title,
+            ],
+        );
+    }
+
+    public function testUnpublishImageRelatedtoPages(): void
+    {
+        $greatGrandChild = $this->objFromFixture(PageFake::class, 'page11');
+
+        $this->assertTrue($greatGrandChild->isPublished());
+
+        $imageFive = $this->objFromFixture(ImageFake::class, 'five');
+        // Queue up a job to remove our Image, the result should be that any related DataObject
+        $job = RemoveDataObjectJob::create(
+            DataObjectDocument::create($imageFive)
+        );
+        $job->setup();
+
+        // Creating this job does not necessarily mean to delete documents from index
+        $this->assertEquals(Indexer::METHOD_ADD, $job->getMethod());
+
+        // Grab what Documents the Job determined it needed to action
+        /** @var DataObjectDocument[] $documents */
+        $documents = $job->getDocuments();
+
+        // There should be two Pages with this Tag assigned
+        $this->assertCount(1, $documents);
+
+        $expectedTitles = [
+            'Great Grandchild of Parent Page 2 - B1 - One',
+        ];
+
+        $resultTitles = [];
+
+        // This determines whether the document should be added or removed from from the index
+        foreach ($documents as $document) {
+            $resultTitles[] = $document->getDataObject()?->Title;
+
+            // The document should be added to index
+            $this->assertTrue($document->shouldIndex());
+        }
+
+        $this->assertEqualsCanonicalizing(
+            $expectedTitles,
+            $resultTitles
+        );
+
+        $this->assertEqualsCanonicalizing(
+            $expectedTitles,
+            [
+                $greatGrandChild->Title,
+            ],
+        );
+    }
+
+}

--- a/tests/pages.yml
+++ b/tests/pages.yml
@@ -1,20 +1,42 @@
+SilverStripe\SearchService\Tests\Fake\TagFake:
+  four:
+    Title: Tag four
+  five:
+    Title: Tag five
+  six:
+    Title: Tag six
+
+SilverStripe\SearchService\Tests\Fake\ImageFake:
+  three:
+    Title: Image Fake Three
+    URL: "/image-three/"
+    Tags: =>SilverStripe\SearchService\Tests\Fake\TagFake.four,=>SilverStripe\SearchService\Tests\Fake\TagFake.five
+  four:
+    Title: Image Fake Four
+    URL: "/image-four/"
+    Tags: =>SilverStripe\SearchService\Tests\Fake\TagFake.five,=>SilverStripe\SearchService\Tests\Fake\TagFake.six
+  five:
+    Title: Image Fake Five
+    URL: "/image-five/"
+    Tags: =>SilverStripe\SearchService\Tests\Fake\TagFake.six
+
 Page:
   page1:
-    Title: Parent Page
+    Title: Parent Page 1
     ShowInSearch: 1
   page2:
-    Title: Child Page 1
+    Title: Child of Parent Page 1 - A
     Parent: =>Page.page1
     ShowInSearch: 1
   page3:
-    Title: Child Page 2
+    Title: Child of Parent Page 1 - B
     Parent: =>Page.page1
     ShowInSearch: 1
   page4:
     Title: Parent Page 2
     ShowInSearch: 1
   page5:
-    Title: Child Page 3
+    Title: Child of Parent Page 2 - A
     Parent: =>Page.page4
     ShowInSearch: 1
   page6:
@@ -22,10 +44,30 @@ Page:
     Subsite: =>SilverStripe\Subsites\Model\Subsite.subsite1
     ShowInSearch: 1
   page7:
-    Title: Grandchild Page 1
+    Title: Grandchild of Parent Page 1 - A1
     Parent: =>Page.page2
     ShowInSearch: 1
   page8:
-    Title: Grandchild Page 2
+    Title: Grandchild of Parent Page 1 - A2
     Parent: =>Page.page2
+    ShowInSearch: 1
+
+SilverStripe\SearchService\Tests\Fake\PageFake:
+  page9:
+    Title: Child of Parent Page 2 - B
+    Parent: =>Page.page4
+    Tags: =>SilverStripe\SearchService\Tests\Fake\TagFake.four,=>SilverStripe\SearchService\Tests\Fake\TagFake.five
+    Images: =>SilverStripe\SearchService\Tests\Fake\ImageFake.three
+    ShowInSearch: 1
+  page10:
+    Title: Grandchild of Parent Page 2 - B1
+    Parent: =>SilverStripe\SearchService\Tests\Fake\PageFake.page9
+    Tags: =>SilverStripe\SearchService\Tests\Fake\TagFake.five,=>SilverStripe\SearchService\Tests\Fake\TagFake.six
+    Images: =>SilverStripe\SearchService\Tests\Fake\ImageFake.four
+    ShowInSearch: 1
+  page11:
+    Title: Great Grandchild of Parent Page 2 - B1 - One
+    Parent: =>SilverStripe\SearchService\Tests\Fake\PageFake.page10
+    Images: =>SilverStripe\SearchService\Tests\Fake\ImageFake.five
+    Tags: =>SilverStripe\SearchService\Tests\Fake\TagFake.four,=>SilverStripe\SearchService\Tests\Fake\TagFake.six
     ShowInSearch: 1

--- a/tests/pages.yml
+++ b/tests/pages.yml
@@ -21,3 +21,11 @@ Page:
     Title: Subsite Page 1
     Subsite: =>SilverStripe\Subsites\Model\Subsite.subsite1
     ShowInSearch: 1
+  page7:
+    Title: Grandchild Page 1
+    Parent: =>Page.page2
+    ShowInSearch: 1
+  page8:
+    Title: Grandchild Page 2
+    Parent: =>Page.page2
+    ShowInSearch: 1


### PR DESCRIPTION
**Issue #88** 

Uses `SiteTree::enforce_strict_hierarchy` config in getting the dependent documents for indexing child pages.