### PR TITLE
FIX Set ShowInSearch db boolean default to true

### DIFF
--- a/src/Extensions/SearchServiceExtension.php
+++ b/src/Extensions/SearchServiceExtension.php
@@ -38,7 +38,7 @@ class SearchServiceExtension extends DataExtension
     use BatchProcessorAware;
 
     private static array $db = [
-        'ShowInSearch' => 'Boolean',
+        'ShowInSearch' => 'Boolean(1)',
         'SearchIndexed' => 'Datetime',
     ];
 

--- a/tests/Fake/DataObjectFakeVersioned.php
+++ b/tests/Fake/DataObjectFakeVersioned.php
@@ -25,7 +25,7 @@ class DataObjectFakeVersioned extends DataObject implements TestOnly
 
     private static array $db = [
         'Title' => 'Varchar',
-        'ShowInSearch' => 'Boolean',
+        'ShowInSearch' => 'Boolean(1)',
     ];
 
     public function canView(mixed $member = null): bool


### PR DESCRIPTION
Fix for #99 

There was a fairly recent change (v3.0.3) that added a 'ShowInSearch' field to the SearchServiceExtension. The change also had a `$defaults` definition to default the value to true, however this only works for new records not existing ones.

Consequently for anyone upgrading existing projects, any DataObject (excluding SiteTree based ones) that uses this extension would have the 'ShowInSearch' column added and any existing records would use the database default of `0` which causes them all to become unindexed upon a full reindex.

I've added in a database default for the 'ShowInSearch' `boolean` definition to default to `1` so that existing records are captured and hopefully no-one else gets caught out.